### PR TITLE
Allow icmpv6 neighbor-solicitation

### DIFF
--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -43,7 +43,7 @@ do
 done
 
 ip6tables -w -A vpnclient_out -d fd00::/8,fe80::/10 -j ACCEPT
-ip6tables -w -A vpnclient_out -s fe80::/10 -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+ip6tables -w -A vpnclient_out -p icmpv6 -j ACCEPT
 ip6tables -w -A vpnclient_out -p udp --dport 5353 -d ff02::fb -j ACCEPT
 ip6tables -w -A vpnclient_out -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 ip6tables -w -A vpnclient_out -j DROP

--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -43,6 +43,7 @@ do
 done
 
 ip6tables -w -A vpnclient_out -d fd00::/8,fe80::/10 -j ACCEPT
+ip6tables -w -A vpnclient_out -s fe80::/10 -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
 ip6tables -w -A vpnclient_out -p udp --dport 5353 -d ff02::fb -j ACCEPT
 ip6tables -w -A vpnclient_out -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 ip6tables -w -A vpnclient_out -j DROP


### PR DESCRIPTION
## Problem

On my statically-configured instance, the neighbor-solicitation packets to the gateway have a link local fe80:: source address and the global unicast address of the gateway as destination. This is blocked by current firewall configuration.

## Solution

Allow neighbor-solicitation packets from fe80:: addresses.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

(only tested by launching `ip6tables -w -I vpnclient_out 10 -s fe80::/10 -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT` manually, I couldn't grasp the workings of `yunohost/hooks.d/post_iptable_rules/90-vpnclient` and `yunohost/apps/vpnclient/conf/hook_post-iptable-rules` before bedtime)

## Automatic tests

!testme

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
