### PR TITLE
Fix typo: s/user-ta.key/user_ta.key 1/

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -320,7 +320,7 @@ ynh_app_config_validate() {
         sed -i 's@^\s*ca\s.*$@ca /etc/openvpn/keys/ca-server.crt@g' ${config_file}
         sed -i 's@^\s*cert\s.*$@cert /etc/openvpn/keys/user.crt@g' ${config_file}
         sed -i 's@^\s*key\s.*$@key /etc/openvpn/keys/user.key@g' ${config_file}
-        sed -i 's@^\s*tls-auth\s.*$@tls-auth /etc/openvpn/keys/user-ta.key@g' ${config_file}
+        sed -i 's@^\s*tls-auth\s.*$@tls-auth /etc/openvpn/keys/user_ta.key 1@g' ${config_file}
     fi
 
     # Currently we need root priviledge to create tun0


### PR DESCRIPTION
## Problem

Configuring from ovpn file makes the service fail to start.
Because the tls-auth param contains 2 typos:
- user-ta.key instead of user_ta.key
- missing " 1" at the end of line

## Solution

Fix the typos :)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

