### PR TITLE
Use default DNS resolvers from Yunohost when DNS settings are empty

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -239,7 +239,7 @@ ynh_app_config_validate() {
         crt_client_key="$(read_cube $config_file crt_client_key)"
         crt_client_ta="$(read_cube $config_file crt_client_ta)"
 
-        if [[ -z $dns0 && -z $dns1 ]]; then
+        if [[ -z "$dns0" && -z "$dns1" ]]; then
           dns_method="yunohost"
         else
           dns_method="custom"

--- a/scripts/config
+++ b/scripts/config
@@ -238,9 +238,14 @@ ynh_app_config_validate() {
         crt_client="$(read_cube $config_file crt_client)"
         crt_client_key="$(read_cube $config_file crt_client_key)"
         crt_client_ta="$(read_cube $config_file crt_client_ta)"
-        dns_method="custom"
-        nameservers="$dns0,$dns1"
 
+        if [[ -z $dns0 && -z $dns1 ]]; then
+          dns_method="yunohost"
+        else
+          dns_method="custom"
+          nameservers="$dns0,$dns1"
+        fi
+        
         # Build specific OVPN template
         tmp_dir=$(dirname "${config_file}")
         cp -f /etc/yunohost/apps/vpnclient/conf/openvpn_client.conf.tpl $tmp_dir/client.conf.tpl


### PR DESCRIPTION
## Problem

The DNS method was hardcoded as "custom" in the cube file importer.
Therefore, when we import a cube file with empty DNS resolvers, it produces an error instead of using the default DNS resolvers from Yunohost.

## Solution

I'm checking if the DNS resolvers from the cube file are empty, then I'm using the default DNS resolvers from Yunohost (dns_method = yunohost).

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
