### PR TITLE
Fix check for IPv6 routes

### DIFF
--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -85,14 +85,15 @@ unset_ip6addr() {
 is_serverip6route_set() {
   server_ip6s=${1}
 
-  if [ -z "${server_ip6}" ]; then
-    false
-  else
-    for server_ip6 in ${server_ip6s};
-    do
-        ip -6 route | grep -q "${server_ip6}/" || return 1
-    done
+  if [[ -z "${server_ip6s}" ]]; then
+    return 0
   fi
+
+  for server_ip6 in ${server_ip6s}; do
+    if ! ip -6 route | grep -q "${server_ip6}"; then
+      return 1
+    fi
+  done
 }
 
 set_serverip6route() {

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -90,7 +90,7 @@ is_serverip6route_set() {
   fi
 
   for server_ip6 in ${server_ip6s}; do
-    if ! ip -6 route | grep -q "${server_ip6}"; then
+    if ! ip -6 route | grep -q "^${server_ip6}"; then
       return 1
     fi
   done


### PR DESCRIPTION
## Problem

The function that checks if the IPv6 routes for the VPN server are set is completely broken. 

The matching pattern was wrong, as I'm getting something like this with `ip -6 route`:
```
default via fe80::abcd:ef01:2345:6789 dev eth0 metric 1024 pref medium
```
While the check was expecting a trailing `/` on the IPv6 address.
This leads to route never getting deleted when the VPN disconnects

## Solution

I fixed the matching pattern and I fixed a typo in the variable name.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
