### PR TITLE
Fix run parts missing operand

### DIFF
--- a/conf/openvpn_client.conf.tpl
+++ b/conf/openvpn_client.conf.tpl
@@ -42,5 +42,5 @@ route-ipv6 2000::/3
 redirect-gateway def1 bypass-dhcp
 
 script-security 2
-route-up "/usr/bin/run-parts /etc/openvpn/scripts/route-up.d"
-down "/usr/bin/run-parts /etc/openvpn/scripts/route-down.d"
+route-up "/etc/openvpn/scripts/run-parts.sh route-up"
+down "/etc/openvpn/scripts/run-parts.sh route-down"

--- a/conf/openvpn_run-parts.sh
+++ b/conf/openvpn_run-parts.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/run-parts -v /etc/openvpn/scripts/$1

--- a/conf/openvpn_run-parts.sh
+++ b/conf/openvpn_run-parts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/run-parts -v /etc/openvpn/scripts/$1
+/usr/bin/run-parts -v /etc/openvpn/scripts/$1.d/

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "en": "Tunnel the internet traffic through a VPN",
     "fr": "Fait passer le trafic internet à travers un VPN"
   },
-  "version": "2.1~ynh1",
+  "version": "2.1.1~ynh1",
   "url": "https://labriqueinter.net",
   "license": "AGPL-3.0",
   "maintainer": {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -39,6 +39,7 @@ function vpnclient_deploy_files_and_services()
   mkdir -pm 0775 /etc/openvpn/scripts
   mkdir -pm 0775 /etc/openvpn/scripts/route-up.d
   mkdir -pm 0775 /etc/openvpn/scripts/route-down.d
+  install -b -o root -g root -m 0755 ../conf/openvpn_run-parts.sh /etc/openvpn/scripts/run-parts.sh
 
   #=================================================
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -36,6 +36,7 @@ ynh_backup "/etc/yunohost/hooks.d/90-vpnclient.tpl"
 
 ynh_backup "/etc/openvpn/client.conf.tpl"
 ynh_backup "/etc/openvpn/keys/"
+ynh_backup "/etc/openvpn/scripts/run-parts.sh"
 
 ynh_backup "/usr/local/bin/$service_name"
 ynh_backup "/usr/local/bin/$service_checker_name.sh"

--- a/scripts/remove
+++ b/scripts/remove
@@ -64,6 +64,9 @@ ynh_print_info "Removing openvpn configuration"
 ynh_secure_remove /etc/openvpn/client.conf
 ynh_secure_remove /etc/openvpn/client.conf.tpl
 
+# Remove openvpn script
+ynh_secure_remove /etc/openvpn/scripts/run-parts.sh
+
 # Remove YunoHost hook
 ynh_secure_remove /etc/yunohost/hooks.d/90-vpnclient.tpl
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -34,6 +34,7 @@ ynh_restore_file "/etc/yunohost/hooks.d/90-vpnclient.tpl"
 
 ynh_restore_file "/etc/openvpn/client.conf.tpl"
 ynh_restore_file "/etc/openvpn/keys/"
+ynh_restore_file "/etc/openvpn/scripts/run-parts.sh"
 
 ynh_restore_file "/usr/local/bin/$service_name"
 ynh_restore_file "/usr/local/bin/$service_checker_name.sh"


### PR DESCRIPTION
## Problem

OpenVPN is sending arguments when running the down script. The problem is that `run-parts` can't handle these extra arguments, and then crashes…

## Solution

I don't have a really clean solution, except creating a bash script that execute `run-parts` without these extra arguments

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
