### PR TITLE
Generate config during upgrade

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -30,7 +30,28 @@ name = "Auto-configuration"
         help = ".cube file recommended, .ovpn file accepted"
         bind = "/etc/openvpn/client.conf"
         redact = true
-        
+
+        [main.vpn.config_template]
+        type = "file"
+        bind = "/etc/openvpn/client.conf.tpl"
+        redact = true
+        optional = true
+        visible = false
+
+        [main.vpn.cube_file]
+        type = "file"
+        bind = "/etc/openvpn/client.cube"
+        redact = true
+        optional = true
+        visible = false
+
+        [main.vpn.ovpn_file]
+        type = "file"
+        bind = "/etc/openvpn/client.ovpn"
+        redact = true
+        optional = true
+        visible = false
+
     [main.auth]
     name = "Authentication"
     optional = true

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -61,3 +61,141 @@ function vpnclient_deploy_files_and_services()
 
   ynh_add_systemd_config $service_checker_name "$service_checker_name.service"
 }
+
+function read_cube() {
+  local config_file="$1"
+  local key="$2"
+  local tmp_dir=$(dirname "$config_file")
+
+  setting_value="$(jq --raw-output ".$key" "$config_file")"
+  if [[ "$setting_value" == "null" ]]
+  then
+    setting_value=''
+  # Save file in tmp dir
+  elif [[ "$key" == "crt_"* ]]
+  then
+    if [ -n "${setting_value}" ]
+    then
+      echo "${setting_value}" | sed 's/|/\n/g' > "$tmp_dir/$key"
+      setting_value="$tmp_dir/$key"
+    fi
+  fi
+  echo $setting_value
+}
+
+function convert_cube_file()
+{
+  local config_file="$1"
+  local tmp_dir=$(dirname "$config_file")
+  
+  ynh_print_info --message="Transforming .cube into OVPN file"
+  server_name="$(read_cube $config_file server_name)"
+  server_port="$(read_cube $config_file server_port)"
+  server_proto="$(read_cube $config_file server_proto)"
+  ip6_net="$(read_cube $config_file ip6_net)"
+  ip6_addr="$(read_cube $config_file ip6_addr)"
+  login_user="$(read_cube $config_file login_user)"
+  login_passphrase="$(read_cube $config_file login_passphrase)"
+  dns0="$(read_cube $config_file dns0)"
+  dns1="$(read_cube $config_file dns1)"
+  crt_server_ca="$(read_cube $config_file crt_server_ca)"
+  crt_client="$(read_cube $config_file crt_client)"
+  crt_client_key="$(read_cube $config_file crt_client_key)"
+  crt_client_ta="$(read_cube $config_file crt_client_ta)"
+
+  if [[ -z "$dns0" && -z "$dns1" ]]; then
+    dns_method="yunohost"
+  else
+    dns_method="custom"
+    nameservers="$dns0,$dns1"
+  fi
+  
+  # Build specific OVPN template
+  config_template="$tmp_dir/client.conf.tpl"
+  cp -f /etc/yunohost/apps/vpnclient/conf/openvpn_client.conf.tpl "$config_template"
+  # Remove some lines
+  jq --raw-output '.openvpn_rm[]' "${config_file}" | while read -r rm_regex
+  do
+    if [ ! -z "${rm_regex}" ]; then
+      sed -i "/${rm_regex/\//\\\/}/d" "$config_template"
+    fi
+  done
+
+  # Add some other lines
+  echo "# Custom additions from .cube" >> "$config_template"
+  jq --raw-output ".openvpn_add[]" "${config_file}" >> "$config_template"
+
+  # Temporarily tweak sever_proto for template hydratation
+  [ "$server_proto" == tcp ] && server_proto=tcp-client
+
+  # Define other needed vars for template hydratation
+  [ -e "$crt_client_key" ] && cert_comment="" || cert_comment="#"
+  [ -e "$crt_client_ta" ] && ta_comment="" || ta_comment="#"
+  [[ "$server_proto" =~ udp ]] && udp_comment="" || udp_comment="#"
+  [ -n "$login_user" ] && login_comment="" || login_comment="#"
+
+  # Actually generate/hydrate the final configuration
+  ynh_add_config --template="$config_template" --destination="$config_file"
+
+  [ "$server_proto" == tcp-client ] && server_proto=tcp
+}
+
+function convert_ovpn_file()
+{
+  local config_file="$1"
+  local tmp_dir=$(dirname "$config_file")
+
+  ynh_print_info --message="Extracting TLS keys from .ovpn file"
+  if grep -q '^\s*<ca>' ${config_file}
+  then
+      grep -Poz '(?<=<ca>)(.*\n)*.*(?=</ca>)' ${config_file} | sed '/^$/d'  > $tmp_dir/crt_server_ca
+      crt_server_ca=$tmp_dir/crt_server_ca
+      sed -i '/^\s*<ca>/,/\s*<\/ca>/d' ${config_file}
+      sed -i '/^\s*ca\s/d' ${config_file}
+      echo -e "\nca /etc/openvpn/keys/ca-server.crt" >> $config_file
+  fi
+  if grep -q '^\s*<cert>' ${config_file}
+  then
+      grep -Poz '(?<=<cert>)(.*\n)*.*(?=</cert>)' ${config_file} | sed '/^$/d'  > $tmp_dir/crt_client
+      crt_client=$tmp_dir/crt_client
+      sed -i '/^\s*<cert>/,/\s*<\/cert>/d' ${config_file}
+      sed -i '/^\s*cert\s/d' ${config_file}
+      echo -e "\ncert /etc/openvpn/keys/user.crt" >> ${config_file}
+  elif ! grep -q '^\s*cert\s' ${config_file}
+  then
+      crt_client=""
+  fi
+  if grep -q '^\s*<key>' ${config_file}
+  then
+      grep -Poz '(?<=<key>)(.*\n)*.*(?=</key>)' ${config_file} | sed '/^$/d' > $tmp_dir/crt_client_key
+      crt_client_key=$tmp_dir/crt_client_key
+      sed -i '/^\s*<key>/,/\s*<\/key>/d' ${config_file}
+      sed -i '/^\s*key\s/d' ${config_file}
+      echo -e "\nkey /etc/openvpn/keys/user.key" >> ${config_file}
+  elif ! grep -q '^\s*key\s' ${config_file}
+  then
+      crt_client_key=""
+  fi
+  if grep -q '^\s*<tls-auth>' ${config_file}
+  then
+      grep -Poz '(?<=<tls-auth>)(.*\n)*.*(?=</tls-auth>)' ${config_file} | sed '/^$/d' > $tmp_dir/crt_client_ta
+      crt_client_ta=$tmp_dir/crt_client_ta
+      sed -i '/^\s*<tls-auth>/,/\s*<\/tls-auth>/d' ${config_file}
+      sed -i '/^\s*tls-auth\s/d' ${config_file}
+      echo -e "\ntls-auth /etc/openvpn/keys/user_ta.key 1" >> ${config_file}
+  elif ! grep -q '^\s*tls-auth\s' ${config_file}
+  then
+      crt_client_ta=""
+  fi
+  sed -i 's@^\s*ca\s.*$@ca /etc/openvpn/keys/ca-server.crt@g' ${config_file}
+  sed -i 's@^\s*cert\s.*$@cert /etc/openvpn/keys/user.crt@g' ${config_file}
+  sed -i 's@^\s*key\s.*$@key /etc/openvpn/keys/user.key@g' ${config_file}
+  sed -i 's@^\s*tls-auth\s.*$@tls-auth /etc/openvpn/keys/user_ta.key 1@g' ${config_file}
+
+  echo -e '\nroute-up "/etc/openvpn/scripts/run-parts.sh route-up"' >> ${config_file}
+  echo -e '\ndown "/etc/openvpn/scripts/run-parts.sh route-down"' >> ${config_file}
+
+  # Currently we need root priviledge to create tun0
+  sed -i '/^\s*user\s/d' ${config_file}
+  sed -i '/^\s*group\s/d' ${config_file}
+}

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -152,52 +152,59 @@ function convert_ovpn_file()
   ynh_print_info --message="Extracting TLS keys from .ovpn file"
   if grep -q '^\s*<ca>' ${config_file}
   then
-      grep -Poz '(?<=<ca>)(.*\n)*.*(?=</ca>)' ${config_file} | sed '/^$/d'  > $tmp_dir/crt_server_ca
-      crt_server_ca=$tmp_dir/crt_server_ca
-      sed -i '/^\s*<ca>/,/\s*<\/ca>/d' ${config_file}
-      sed -i '/^\s*ca\s/d' ${config_file}
-      echo -e "\nca /etc/openvpn/keys/ca-server.crt" >> $config_file
+    grep -Poz '(?<=<ca>)(.*\n)*.*(?=</ca>)' ${config_file} | sed '/^$/d'  > $tmp_dir/crt_server_ca
+    crt_server_ca=$tmp_dir/crt_server_ca
+    sed -i '/^\s*<ca>/,/\s*<\/ca>/d' ${config_file}
+    sed -i '/^\s*ca\s/d' ${config_file}
+    echo -e "\nca /etc/openvpn/keys/ca-server.crt" >> $config_file
   fi
   if grep -q '^\s*<cert>' ${config_file}
   then
-      grep -Poz '(?<=<cert>)(.*\n)*.*(?=</cert>)' ${config_file} | sed '/^$/d'  > $tmp_dir/crt_client
-      crt_client=$tmp_dir/crt_client
-      sed -i '/^\s*<cert>/,/\s*<\/cert>/d' ${config_file}
-      sed -i '/^\s*cert\s/d' ${config_file}
-      echo -e "\ncert /etc/openvpn/keys/user.crt" >> ${config_file}
+    grep -Poz '(?<=<cert>)(.*\n)*.*(?=</cert>)' ${config_file} | sed '/^$/d'  > $tmp_dir/crt_client
+    crt_client=$tmp_dir/crt_client
+    sed -i '/^\s*<cert>/,/\s*<\/cert>/d' ${config_file}
+    sed -i '/^\s*cert\s/d' ${config_file}
+    echo -e "\ncert /etc/openvpn/keys/user.crt" >> ${config_file}
   elif ! grep -q '^\s*cert\s' ${config_file}
   then
-      crt_client=""
+    crt_client=""
   fi
   if grep -q '^\s*<key>' ${config_file}
   then
-      grep -Poz '(?<=<key>)(.*\n)*.*(?=</key>)' ${config_file} | sed '/^$/d' > $tmp_dir/crt_client_key
-      crt_client_key=$tmp_dir/crt_client_key
-      sed -i '/^\s*<key>/,/\s*<\/key>/d' ${config_file}
-      sed -i '/^\s*key\s/d' ${config_file}
-      echo -e "\nkey /etc/openvpn/keys/user.key" >> ${config_file}
+    grep -Poz '(?<=<key>)(.*\n)*.*(?=</key>)' ${config_file} | sed '/^$/d' > $tmp_dir/crt_client_key
+    crt_client_key=$tmp_dir/crt_client_key
+    sed -i '/^\s*<key>/,/\s*<\/key>/d' ${config_file}
+    sed -i '/^\s*key\s/d' ${config_file}
+    echo -e "\nkey /etc/openvpn/keys/user.key" >> ${config_file}
   elif ! grep -q '^\s*key\s' ${config_file}
   then
-      crt_client_key=""
+    crt_client_key=""
   fi
   if grep -q '^\s*<tls-auth>' ${config_file}
   then
-      grep -Poz '(?<=<tls-auth>)(.*\n)*.*(?=</tls-auth>)' ${config_file} | sed '/^$/d' > $tmp_dir/crt_client_ta
-      crt_client_ta=$tmp_dir/crt_client_ta
-      sed -i '/^\s*<tls-auth>/,/\s*<\/tls-auth>/d' ${config_file}
-      sed -i '/^\s*tls-auth\s/d' ${config_file}
-      echo -e "\ntls-auth /etc/openvpn/keys/user_ta.key 1" >> ${config_file}
+    grep -Poz '(?<=<tls-auth>)(.*\n)*.*(?=</tls-auth>)' ${config_file} | sed '/^$/d' > $tmp_dir/crt_client_ta
+    crt_client_ta=$tmp_dir/crt_client_ta
+    sed -i '/^\s*<tls-auth>/,/\s*<\/tls-auth>/d' ${config_file}
+    sed -i '/^\s*tls-auth\s/d' ${config_file}
+    echo -e "\ntls-auth /etc/openvpn/keys/user_ta.key 1" >> ${config_file}
   elif ! grep -q '^\s*tls-auth\s' ${config_file}
   then
-      crt_client_ta=""
+    crt_client_ta=""
   fi
   sed -i 's@^\s*ca\s.*$@ca /etc/openvpn/keys/ca-server.crt@g' ${config_file}
   sed -i 's@^\s*cert\s.*$@cert /etc/openvpn/keys/user.crt@g' ${config_file}
   sed -i 's@^\s*key\s.*$@key /etc/openvpn/keys/user.key@g' ${config_file}
   sed -i 's@^\s*tls-auth\s.*$@tls-auth /etc/openvpn/keys/user_ta.key 1@g' ${config_file}
 
-  echo -e '\nroute-up "/etc/openvpn/scripts/run-parts.sh route-up"' >> ${config_file}
-  echo -e '\ndown "/etc/openvpn/scripts/run-parts.sh route-down"' >> ${config_file}
+  if ! grep -q '^\s*route-up "/etc/openvpn/scripts/run-parts.sh route-up"' ${config_file}
+  then
+    echo -e 'route-up "/etc/openvpn/scripts/run-parts.sh route-up"' >> ${config_file}
+  fi
+  
+  if ! grep -q '^\s*down "/etc/openvpn/scripts/run-parts.sh route-down"' ${config_file}
+  then
+    echo -e 'down "/etc/openvpn/scripts/run-parts.sh route-down"' >> ${config_file}
+  fi
 
   # Currently we need root priviledge to create tun0
   sed -i '/^\s*user\s/d' ${config_file}

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -126,7 +126,9 @@ function convert_cube_file()
   jq --raw-output ".openvpn_add[]" "${config_file}" >> "$config_template"
 
   # Temporarily tweak sever_proto for template hydratation
-  [ "$server_proto" == tcp ] && server_proto=tcp-client
+  if [ "$server_proto" == tcp ]; then
+    server_proto=tcp-client
+  fi
 
   # Define other needed vars for template hydratation
   [ -e "$crt_client_key" ] && cert_comment="" || cert_comment="#"
@@ -137,7 +139,9 @@ function convert_cube_file()
   # Actually generate/hydrate the final configuration
   ynh_add_config --template="$config_template" --destination="$config_file"
 
-  [ "$server_proto" == tcp-client ] && server_proto=tcp
+  if [ "$server_proto" == tcp-client ]; then
+    server_proto=tcp
+  fi
 }
 
 function convert_ovpn_file()

--- a/scripts/backup
+++ b/scripts/backup
@@ -35,6 +35,10 @@ ynh_backup "/usr/local/bin/$service_name-loadcubefile.sh"
 ynh_backup "/etc/yunohost/hooks.d/90-vpnclient.tpl"
 
 ynh_backup "/etc/openvpn/client.conf.tpl"
+ynh_backup "/etc/openvpn/client.conf" --not_mandatory
+ynh_backup "/etc/openvpn/client.cube" --not_mandatory
+ynh_backup "/etc/openvpn/client.ovpn" --not_mandatory
+
 ynh_backup "/etc/openvpn/keys/"
 ynh_backup "/etc/openvpn/scripts/run-parts.sh"
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -30,20 +30,20 @@ app=$YNH_APP_INSTANCE_NAME
 #=================================================
 ynh_print_info "Backing up the main app directory..."
 
-ynh_backup "/usr/local/bin/$service_name-loadcubefile.sh"
+ynh_backup --src_path="/usr/local/bin/$service_name-loadcubefile.sh"
 
-ynh_backup "/etc/yunohost/hooks.d/90-vpnclient.tpl"
+ynh_backup --src_path="/etc/yunohost/hooks.d/90-vpnclient.tpl"
 
-ynh_backup "/etc/openvpn/client.conf.tpl"
-ynh_backup "/etc/openvpn/client.conf" --not_mandatory
-ynh_backup "/etc/openvpn/client.cube" --not_mandatory
-ynh_backup "/etc/openvpn/client.ovpn" --not_mandatory
+ynh_backup --src_path="/etc/openvpn/client.conf.tpl"
+ynh_backup --src_path="/etc/openvpn/client.conf" --not_mandatory
+ynh_backup --src_path="/etc/openvpn/client.cube" --not_mandatory
+ynh_backup --src_path="/etc/openvpn/client.ovpn" --not_mandatory
 
-ynh_backup "/etc/openvpn/keys/"
-ynh_backup "/etc/openvpn/scripts/run-parts.sh"
+ynh_backup --src_path="/etc/openvpn/keys/"
+ynh_backup --src_path="/etc/openvpn/scripts/run-parts.sh"
 
-ynh_backup "/usr/local/bin/$service_name"
-ynh_backup "/usr/local/bin/$service_checker_name.sh"
+ynh_backup --src_path="/usr/local/bin/$service_name"
+ynh_backup --src_path="/usr/local/bin/$service_checker_name.sh"
 
 #=================================================
 # SPECIFIC BACKUP
@@ -52,10 +52,10 @@ ynh_backup "/usr/local/bin/$service_checker_name.sh"
 #=================================================
 ynh_print_info "Backing up systemd configuration..."
 
-ynh_backup "/etc/systemd/system/$service_name.service"
-ynh_backup "/etc/systemd/system/$service_checker_name.service"
-ynh_backup "/etc/systemd/system/$service_checker_name.timer"
-ynh_backup "/etc/systemd/system/openvpn@.service.d/override.conf"
+ynh_backup --src_path="/etc/systemd/system/$service_name.service"
+ynh_backup --src_path="/etc/systemd/system/$service_checker_name.service"
+ynh_backup --src_path="/etc/systemd/system/$service_checker_name.timer"
+ynh_backup --src_path="/etc/systemd/system/openvpn@.service.d/override.conf"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/config
+++ b/scripts/config
@@ -213,7 +213,6 @@ ynh_app_config_validate() {
         cp -f "$config_file" "$cube_file"
 
         convert_cube_file "$config_file"
-
     # Othewise, assume that it's a .ovpn / .conf
     elif [ -f "${config_file}" ]
     then
@@ -248,6 +247,10 @@ ynh_app_config_apply() {
     set_permissions /etc/openvpn/keys/user.crt
     set_permissions /etc/openvpn/keys/user.key
     set_permissions /etc/openvpn/keys/user_ta.key
+
+    # Cleanup previously uploaded config file
+    [[ -f $cube_file ]] || rm -f /etc/openvpn/client.cube
+    [[ -f $ovpn_file ]] || rm -f /etc/openvpn/client.ovpn
 
     # Start vpn client
     ynh_print_info --message="Starting vpnclient service if needed"

--- a/scripts/config
+++ b/scripts/config
@@ -212,17 +212,17 @@ ynh_app_config_validate() {
         cube_file="$tmp_dir/client.cube"
         cp -f "$config_file" "$cube_file"
 
-        convert_cube_file
+        convert_cube_file "$config_file"
 
     # Othewise, assume that it's a .ovpn / .conf
     elif [ -f "${config_file}" ]
     then
         local tmp_dir=$(dirname "$config_file")
-        
+
         ovpn_file="$tmp_dir/client.ovpn"
         cp -f "$config_file" "$ovpn_file"
 
-        convert_ovpn_file
+        convert_ovpn_file "$config_file"
     fi
 
     _ynh_app_config_validate

--- a/scripts/config
+++ b/scripts/config
@@ -249,8 +249,8 @@ ynh_app_config_apply() {
     set_permissions /etc/openvpn/keys/user_ta.key
 
     # Cleanup previously uploaded config file
-    [[ -f $cube_file ]] || rm -f /etc/openvpn/client.cube
-    [[ -f $ovpn_file ]] || rm -f /etc/openvpn/client.ovpn
+    [[ "$cube_file" == "/etc/openvpn/client.cube" ]] && rm -f "$cube_file"
+    [[ "$ovpn_file" == "/etc/openvpn/client.ovpn" ]] && rm -f "$ovpn_file"
 
     # Start vpn client
     ynh_print_info --message="Starting vpnclient service if needed"

--- a/scripts/config
+++ b/scripts/config
@@ -195,23 +195,6 @@ set__login_passphrase() {
 #=================================================
 # OVERWRITING VALIDATE STEP
 #=================================================
-read_cube() {
-    tmp_dir=$(dirname "$1")
-    setting_value="$(jq --raw-output ".$2" "$1")"
-    if [[ "$setting_value" == "null" ]]
-    then
-        setting_value=''
-    # Save file in tmp dir
-    elif [[ "$2" == "crt_"* ]]
-    then
-        if [ -n "${setting_value}" ]
-        then
-            echo "${setting_value}" | sed 's/|/\n/g' > $tmp_dir/$2
-            setting_value="$tmp_dir/$2"
-        fi
-    fi
-    echo $setting_value
-}
 ynh_app_config_validate() {
     # At this moment this var is not already set with the old value
     if [ -z ${config_file+x} ]
@@ -224,115 +207,22 @@ ynh_app_config_validate() {
     # (i.e. it starts with { ..)
     elif [ -f "${config_file}" ] && [[ "$(cat ${config_file} | tr -d ' ' | grep -v "^$" | head -c1)" == "{" ]]
     then
-        ynh_print_info --message="Transforming .cube into OVPN file"
-        server_name="$(read_cube $config_file server_name)"
-        server_port="$(read_cube $config_file server_port)"
-        server_proto="$(read_cube $config_file server_proto)"
-        ip6_net="$(read_cube $config_file ip6_net)"
-        ip6_addr="$(read_cube $config_file ip6_addr)"
-        login_user="$(read_cube $config_file login_user)"
-        login_passphrase="$(read_cube $config_file login_passphrase)"
-        dns0="$(read_cube $config_file dns0)"
-        dns1="$(read_cube $config_file dns1)"
-        crt_server_ca="$(read_cube $config_file crt_server_ca)"
-        crt_client="$(read_cube $config_file crt_client)"
-        crt_client_key="$(read_cube $config_file crt_client_key)"
-        crt_client_ta="$(read_cube $config_file crt_client_ta)"
+        local tmp_dir=$(dirname "$config_file")
 
-        if [[ -z "$dns0" && -z "$dns1" ]]; then
-          dns_method="yunohost"
-        else
-          dns_method="custom"
-          nameservers="$dns0,$dns1"
-        fi
-        
-        # Build specific OVPN template
-        tmp_dir=$(dirname "${config_file}")
-        cp -f /etc/yunohost/apps/vpnclient/conf/openvpn_client.conf.tpl $tmp_dir/client.conf.tpl
-        # Remove some lines
-        jq --raw-output '.openvpn_rm[]' "${config_file}" | while read -r rm_regex
-        do
-            if [ ! -z "${rm_regex}" ] ; then
-		sed -i "/${rm_regex/\//\\\/}/d" $tmp_dir/client.conf.tpl
-            fi
-        done
+        cube_file="$tmp_dir/client.cube"
+        cp -f "$config_file" "$cube_file"
 
-        # Add some other lines
-        echo "# Custom additions from .cube" >> $tmp_dir/client.conf.tpl
-        jq --raw-output ".openvpn_add[]" "${config_file}" >> $tmp_dir/client.conf.tpl
-
-        # Temporarily tweak sever_proto for template hydratation
-        [ "$server_proto" == tcp ] && server_proto=tcp-client
-
-        # Define other needed vars for template hydratation
-        [ -e "$crt_client_key" ] && cert_comment="" || cert_comment="#"
-        [ -e "$crt_client_ta" ] && ta_comment="" || ta_comment="#"
-        [[ "$server_proto" =~ udp ]] && udp_comment="" || udp_comment="#"
-        [ -n "$login_user" ] && login_comment="" || login_comment="#"
-
-        # Actually generate/hydrate the final configuration
-        ynh_add_config --template="$tmp_dir/client.conf.tpl" --destination="${config_file}"
-
-        [ "$server_proto" == tcp-client ] && server_proto=tcp
-
+        convert_cube_file
 
     # Othewise, assume that it's a .ovpn / .conf
     elif [ -f "${config_file}" ]
     then
-        tmp_dir=$(dirname "${config_file}")
-        ynh_print_info --message="Extracting TLS keys from .ovpn file"
-        if grep -q '^\s*<ca>' ${config_file}
-        then
-            grep -Poz '(?<=<ca>)(.*\n)*.*(?=</ca>)' ${config_file} | sed '/^$/d'  > $tmp_dir/crt_server_ca
-            crt_server_ca=$tmp_dir/crt_server_ca
-            sed -i '/^\s*<ca>/,/\s*<\/ca>/d' ${config_file}
-            sed -i '/^\s*ca\s/d' ${config_file}
-            echo -e "\nca /etc/openvpn/keys/ca-server.crt" >> ${config_file}
-        fi
-        if grep -q '^\s*<cert>' ${config_file}
-        then
-            grep -Poz '(?<=<cert>)(.*\n)*.*(?=</cert>)' ${config_file} | sed '/^$/d'  > $tmp_dir/crt_client
-            crt_client=$tmp_dir/crt_client
-            sed -i '/^\s*<cert>/,/\s*<\/cert>/d' ${config_file}
-            sed -i '/^\s*cert\s/d' ${config_file}
-            echo -e "\ncert /etc/openvpn/keys/user.crt" >> ${config_file}
-        elif ! grep -q '^\s*cert\s' ${config_file}
-        then
-            crt_client=""
-        fi
-        if grep -q '^\s*<key>' ${config_file}
-        then
-            grep -Poz '(?<=<key>)(.*\n)*.*(?=</key>)' ${config_file} | sed '/^$/d' > $tmp_dir/crt_client_key
-            crt_client_key=$tmp_dir/crt_client_key
-            sed -i '/^\s*<key>/,/\s*<\/key>/d' ${config_file}
-            sed -i '/^\s*key\s/d' ${config_file}
-            echo -e "\nkey /etc/openvpn/keys/user.key" >> ${config_file}
-        elif ! grep -q '^\s*key\s' ${config_file}
-        then
-            crt_client_key=""
-        fi
-        if grep -q '^\s*<tls-auth>' ${config_file}
-        then
-            grep -Poz '(?<=<tls-auth>)(.*\n)*.*(?=</tls-auth>)' ${config_file} | sed '/^$/d' > $tmp_dir/crt_client_ta
-            crt_client_ta=$tmp_dir/crt_client_ta
-            sed -i '/^\s*<tls-auth>/,/\s*<\/tls-auth>/d' ${config_file}
-            sed -i '/^\s*tls-auth\s/d' ${config_file}
-            echo -e "\ntls-auth /etc/openvpn/keys/user_ta.key 1" >> ${config_file}
-        elif ! grep -q '^\s*tls-auth\s' ${config_file}
-        then
-            crt_client_ta=""
-        fi
-        sed -i 's@^\s*ca\s.*$@ca /etc/openvpn/keys/ca-server.crt@g' ${config_file}
-        sed -i 's@^\s*cert\s.*$@cert /etc/openvpn/keys/user.crt@g' ${config_file}
-        sed -i 's@^\s*key\s.*$@key /etc/openvpn/keys/user.key@g' ${config_file}
-        sed -i 's@^\s*tls-auth\s.*$@tls-auth /etc/openvpn/keys/user_ta.key 1@g' ${config_file}
-    fi
+        local tmp_dir=$(dirname "$config_file")
+        
+        ovpn_file="$tmp_dir/client.ovpn"
+        cp -f "$config_file" "$ovpn_file"
 
-    # Currently we need root priviledge to create tun0
-    if [ -f "${config_file}" ]
-    then
-        sed -i '/^\s*user\s/d' ${config_file}
-        sed -i '/^\s*group\s/d' ${config_file}
+        convert_ovpn_file
     fi
 
     _ynh_app_config_validate

--- a/scripts/remove
+++ b/scripts/remove
@@ -63,6 +63,8 @@ ynh_print_info "Removing openvpn configuration"
 # Remove openvpn configurations
 ynh_secure_remove /etc/openvpn/client.conf
 ynh_secure_remove /etc/openvpn/client.conf.tpl
+ynh_secure_remove /etc/openvpn/client.cube
+ynh_secure_remove /etc/openvpn/client.ovpn
 
 # Remove openvpn script
 ynh_secure_remove /etc/openvpn/scripts/run-parts.sh

--- a/scripts/restore
+++ b/scripts/restore
@@ -28,20 +28,20 @@ app=$YNH_APP_INSTANCE_NAME
 #=================================================
 ynh_print_info "Restoring the app files..."
 
-ynh_restore_file "/usr/local/bin/$service_name-loadcubefile.sh"
+ynh_restore_file --origin_path="/usr/local/bin/$service_name-loadcubefile.sh"
 
-ynh_restore_file "/etc/yunohost/hooks.d/90-vpnclient.tpl"
+ynh_restore_file --origin_path="/etc/yunohost/hooks.d/90-vpnclient.tpl"
 
-ynh_restore_file "/etc/openvpn/client.conf.tpl"
-ynh_restore_file "/etc/openvpn/client.conf" --not_mandatory
-ynh_restore_file "/etc/openvpn/client.cube" --not_mandatory
-ynh_restore_file "/etc/openvpn/client.ovpn" --not_mandatory
+ynh_restore_file --origin_path="/etc/openvpn/client.conf.tpl"
+ynh_restore_file --origin_path="/etc/openvpn/client.conf" --not_mandatory
+ynh_restore_file --origin_path="/etc/openvpn/client.cube" --not_mandatory
+ynh_restore_file --origin_path="/etc/openvpn/client.ovpn" --not_mandatory
 
-ynh_restore_file "/etc/openvpn/keys/"
-ynh_restore_file "/etc/openvpn/scripts/run-parts.sh"
+ynh_restore_file --origin_path="/etc/openvpn/keys/"
+ynh_restore_file --origin_path="/etc/openvpn/scripts/run-parts.sh"
 
-ynh_restore_file "/usr/local/bin/$service_name"
-ynh_restore_file "/usr/local/bin/$service_checker_name.sh"
+ynh_restore_file --origin_path="/usr/local/bin/$service_name"
+ynh_restore_file --origin_path="/usr/local/bin/$service_checker_name.sh"
 
 #=================================================
 # RECREATE THE DEDICATED USER
@@ -66,10 +66,10 @@ ynh_install_app_dependencies "$pkg_dependencies"
 #=================================================
 ynh_print_info "Restoring the systemd configuration..."
 
-ynh_restore_file "/etc/systemd/system/$service_name.service"
-ynh_restore_file "/etc/systemd/system/$service_checker_name.service"
-ynh_restore_file "/etc/systemd/system/$service_checker_name.timer"
-ynh_restore_file "/etc/systemd/system/openvpn@.service.d/override.conf"
+ynh_restore_file --origin_path="/etc/systemd/system/$service_name.service"
+ynh_restore_file --origin_path="/etc/systemd/system/$service_checker_name.service"
+ynh_restore_file --origin_path="/etc/systemd/system/$service_checker_name.timer"
+ynh_restore_file --origin_path="/etc/systemd/system/openvpn@.service.d/override.conf"
 systemctl daemon-reload
 systemctl enable "$service_name.service" --quiet
 systemctl enable "$service_checker_name.service" --quiet

--- a/scripts/restore
+++ b/scripts/restore
@@ -33,6 +33,10 @@ ynh_restore_file "/usr/local/bin/$service_name-loadcubefile.sh"
 ynh_restore_file "/etc/yunohost/hooks.d/90-vpnclient.tpl"
 
 ynh_restore_file "/etc/openvpn/client.conf.tpl"
+ynh_restore_file "/etc/openvpn/client.conf" --not_mandatory
+ynh_restore_file "/etc/openvpn/client.cube" --not_mandatory
+ynh_restore_file "/etc/openvpn/client.ovpn" --not_mandatory
+
 ynh_restore_file "/etc/openvpn/keys/"
 ynh_restore_file "/etc/openvpn/scripts/run-parts.sh"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,14 +114,20 @@ cp -r /etc/openvpn/client* ${tmp_dir}
 # Deploy files from package
 vpnclient_deploy_files_and_services
 
-# Generate config file from .cube or .ovpn file, if available
+# Generate config file from the uploaded .cube or .ovpn file, if available
 if [[ -f "$tmp_dir/client.cube" ]]
 then
     cp -f "$tmp_dir/client.cube" "$tmp_dir/client.conf"
     convert_cube_file "$tmp_dir/client.conf"
-elif [[ -f "$tmp_dir/client.ovpn" ]]
-then
-    cp -f "$tmp_dir/client.ovpn" "$tmp_dir/client.conf"
+else
+    if [[ -f "$tmp_dir/client.ovpn" ]]
+    then
+        cp -f "$tmp_dir/client.ovpn" "$tmp_dir/client.conf"
+    else
+        # In case we didn't keep the uploaded .ovpn file, we create one from the current config...
+        cp -f "$tmp_dir/client.conf" "$tmp_dir/client.ovpn"
+    fi
+
     convert_ovpn_file "$tmp_dir/client.conf"
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -117,10 +117,12 @@ vpnclient_deploy_files_and_services
 # Generate config file from .cube or .ovpn file, if available
 if [[ -f "$tmp_dir/client.cube" ]]
 then
-    convert_cube_file "$tmp_dir/client.cube"
+    cp -f "$tmp_dir/client.cube" "$tmp_dir/client.conf"
+    convert_cube_file "$tmp_dir/client.conf"
 elif [[ -f "$tmp_dir/client.ovpn" ]]
 then
-    convert_ovpn_file "$tmp_dir/client.ovpn"
+    cp -f "$tmp_dir/client.ovpn" "$tmp_dir/client.conf"
+    convert_ovpn_file "$tmp_dir/client.conf"
 fi
 
 # Restore previously existing config files

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -108,15 +108,24 @@ ynh_install_app_dependencies "$pkg_dependencies"
 #=================================================
 
 # Keep a copy of existing config files before overwriting them
-tmpdir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
-cp -r /etc/openvpn/client* ${tmpdir}
+tmp_dir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
+cp -r /etc/openvpn/client* ${tmp_dir}
 
 # Deploy files from package
 vpnclient_deploy_files_and_services
 
+# Generate config file from .cube or .ovpn file, if available
+if [[ -f "$tmp_dir/client.cube"]]
+then
+    convert_cube_file "$tmp_dir/client.cube"
+elif [[ -f "$tmp_dir/client.ovpn" ]]
+then
+    convert_ovpn_file "$tmp_dir/client.ovpn"
+fi
+
 # Restore previously existing config files
-cp -r ${tmpdir}/client* /etc/openvpn/
-ynh_secure_remove ${tmpdir}
+cp -r ${tmp_dir}/client* /etc/openvpn/
+ynh_secure_remove ${tmp_dir}
 
 #=================================================
 # SERVICE INTEGRATION IN YUNOHOST

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -119,15 +119,14 @@ if [[ -f "$tmp_dir/client.cube" ]]
 then
     cp -f "$tmp_dir/client.cube" "$tmp_dir/client.conf"
     convert_cube_file "$tmp_dir/client.conf"
-else
-    if [[ -f "$tmp_dir/client.ovpn" ]]
-    then
-        cp -f "$tmp_dir/client.ovpn" "$tmp_dir/client.conf"
-    else
-        # In case we didn't keep the uploaded .ovpn file, we create one from the current config...
-        cp -f "$tmp_dir/client.conf" "$tmp_dir/client.ovpn"
-    fi
-
+elif [[ -f "$tmp_dir/client.ovpn" ]]
+then
+    cp -f "$tmp_dir/client.ovpn" "$tmp_dir/client.conf"
+    convert_ovpn_file "$tmp_dir/client.conf"
+# In case we didn't keep the uploaded .ovpn file, we create one from the current config...
+elif [[ -f "$tmp_dir/client.conf" ]]
+then
+    cp -f "$tmp_dir/client.conf" "$tmp_dir/client.ovpn"
     convert_ovpn_file "$tmp_dir/client.conf"
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -115,7 +115,7 @@ cp -r /etc/openvpn/client* ${tmp_dir}
 vpnclient_deploy_files_and_services
 
 # Generate config file from .cube or .ovpn file, if available
-if [[ -f "$tmp_dir/client.cube"]]
+if [[ -f "$tmp_dir/client.cube" ]]
 then
     convert_cube_file "$tmp_dir/client.cube"
 elif [[ -f "$tmp_dir/client.ovpn" ]]

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -132,6 +132,7 @@ ynh_secure_remove ${tmp_dir}
 #=================================================
 
 ### Make sure that the yunohost services have a description and need-lock enabled
+ynh_print_info "Configuring VPN client services..."
 
 # main service
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/ynh-vpnclient.log"


### PR DESCRIPTION
## Problem

As explained in #112, the config file isn't generated during the upgrade, so it's difficult to improve the config, as I did with the hook scripts introduced in #107 

## Solution

I propose to store the uploaded config file as client.cube or client.ovpn file, and generate the config again each time the app is upgraded.

As the file wasn't stored before these changes, I'm simply copying the client.conf to client.ovpn and starting from there. As a side effect, custom changes made by the user won't be overwritten for them. 

The config file will be overwritten only for uploaded config file starting from this PR.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
