### PR TITLE
Don't try to resolve DNS when VPN server is not a domain

### DIFF
--- a/conf/hook_post-iptable-rules
+++ b/conf/hook_post-iptable-rules
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 server_names=$(grep -o -P '^\s*remote\s+\K([^\s]+)' /etc/openvpn/client.conf | sort | uniq)
-host6=$(dig AAAA +short $server_names @127.0.0.1 | grep -v '\.$' | grep -v "timed out")
-host4=$(dig A +short $server_names @127.0.0.1 | grep -v '\.$' | grep -v "timed out")
 
 # In case an ip has been provided in ovpn conf
+host4=""
+host6=""
 for i in ${server_names}; do
   if [[ "${i}" =~ : ]]; then
       host6+=" ${i}"
@@ -13,8 +13,16 @@ for i in ${server_names}; do
   fi
 done
 
+if [[ -z "${host6}" ]]; then
+  host6=$(dig AAAA +short $server_names @127.0.0.1 | grep -v '\.$' | grep -v "timed out")
+fi
+
+if [[ -z "${host4}" ]]; then
+  host4=$(dig A +short $server_names @127.0.0.1 | grep -v '\.$' | grep -v "timed out")
+fi
+
 interface=$(ip route | awk '/default via/ { print $5; }')
-dns=$(grep -o -P '\s*nameserver\s+\K[ABCDEFabcdef\d.:]+' /etc/resolv.dnsmasq.conf)
+dns=$(grep -o -P '^\s*nameserver\s+\K[a-fA-F\d.:]+$' /etc/resolv.dnsmasq.conf | sort | uniq)
 
 # IPv6
 

--- a/conf/scripts/route-down.d/10-vpnclient-unset-firewall
+++ b/conf/scripts/route-down.d/10-vpnclient-unset-firewall
@@ -7,9 +7,8 @@ is_firewall_set() {
 
 wired_device=$(ip route | awk '/default via/ { print $5; }')
 
-if is_firewall_set; then
-  rm -f /etc/yunohost/hooks.d/post_iptable_rules/90-vpnclient
-  
+rm -f /etc/yunohost/hooks.d/post_iptable_rules/90-vpnclient
+if is_firewall_set; then  
   # IPv4
 
   iptables -w -D INPUT -i "${wired_device}" -j vpnclient_in

--- a/conf/scripts/route-up.d/10-vpnclient-set-firewall
+++ b/conf/scripts/route-up.d/10-vpnclient-set-firewall
@@ -9,8 +9,8 @@ is_firewall_set() {
 
 if ! is_firewall_set; then
   bash /etc/yunohost/apps/vpnclient/conf/hook_post-iptable-rules
-  cp /etc/yunohost/apps/vpnclient/conf/hook_post-iptable-rules /etc/yunohost/hooks.d/post_iptable_rules/90-vpnclient
 fi
+cp /etc/yunohost/apps/vpnclient/conf/hook_post-iptable-rules /etc/yunohost/hooks.d/post_iptable_rules/90-vpnclient
 
 if is_firewall_set; then
   echo "[ OK ] IPv6/IPv4 firewall set"

--- a/conf/scripts/route-up.d/30-vpnclient-set-server-ipv6-route
+++ b/conf/scripts/route-up.d/30-vpnclient-set-server-ipv6-route
@@ -45,13 +45,21 @@ old_server_ip6=$(yunohost app setting vpnclient server_ip6)
 new_ip6_gw=$(ip -6 route | awk '/default via/ { print $3 }')
 new_wired_device=$(ip route | awk '/default via/ { print $5; }')
 ynh_server_names=$(grep -o -P '^\s*remote\s+\K([^\s]+)' /etc/openvpn/client.conf | sort | uniq)
-new_server_ip6=$(dig AAAA +short $ynh_server_names @127.0.0.1 | grep -v '\.$' | grep -v "timed out" | sort | uniq)
 
+# In case an ip has been provided in ovpn conf
+new_server_ip6=""
+new_server_ip4=""
 for i in $ynh_server_names; do
-  if [[ "${i}" =~ : ]] && [[ ! "$new_server_ip6" == *"${i}"* ]] ; then
+  if [[ "${i}" =~ : ]]; then
     new_server_ip6+=" ${i}"
+  elif [[ "${i}" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+    new_server_ip4+=" ${i}"
   fi
 done
+
+if [[ -z "${new_server_ip6}" && -z "${new_server_ip4}" ]]; then
+  new_server_ip6=$(dig AAAA +short $ynh_server_names @127.0.0.1 | grep -v '\.$' | grep -v "timed out" | sort | uniq)
+fi
 
 echo "[INFO] Autodetected internet interface: ${new_wired_device} (last start: ${old_wired_device})"
 echo "[INFO] Autodetected IPv6 address for the VPN server: ${new_server_ip6} (last start: ${old_server_ip6})"

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -211,7 +211,7 @@ case "$action" in
         critical "The VPN is up but debian.org cannot be reached, indicating that something is probably misconfigured/blocked."
       fi
     else
-      critical "[CRIT] IPv4 routes are misconfigured !?"
+      critical "IPv4 routes are misconfigured !?"
     fi
   ;;
 


### PR DESCRIPTION
## Problem

See https://forum.arn-fai.net/t/18-04-2024-ne-pas-mettre-a-jour-vos-vpnclient-ynh/9495/2

In short, VPN client can sometimes timeout if the keepalive session is too low and the server is slow (for instance on internet cubes). I noticed that the client was trying to do DNS resolution on IP address, which is useless. The idea is to reduce the time needed for the client to connect.

## Solution

First check if the VPN remote address is an IP or a domain. If it's a domain, proceed with DNS resolution to obtain the IP address.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
