### PR TITLE
Remove check for CA server certificate expiry date

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -1,6 +1,7 @@
 # All available README files by language
 
 - [Read the README in English](README.md)
+- [Lea el README en español](README_es.md)
 - [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)
 - [Le o README en galego](README_gl.md)

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,52 @@
+<!--
+Este archivo README esta generado automaticamente<https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+No se debe editar a mano.
+-->
+
+# VPN Client para Yunohost
+
+[![Nivel de integración](https://dash.yunohost.org/integration/vpnclient.svg)](https://dash.yunohost.org/appci/app/vpnclient) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+
+[![Instalar VPN Client con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
+
+*[Leer este README en otros idiomas.](./ALL_README.md)*
+
+> *Este paquete le permite instalarVPN Client rapidamente y simplement en un servidor YunoHost.*  
+> *Si no tiene YunoHost, visita [the guide](https://yunohost.org/install) para aprender como instalarla.*
+
+## Descripción general
+
+Install a VPN connection on your self-hosted server.
+* Useful for hosting your server behind a filtered (and/or non-neutral) internet access.
+* Useful to have static IP addresses (IPv6 and IPv4).
+* Useful to easily move your server anywhere.
+* Strong firewalling (internet access and self-hosted services only available through the VPN, not leaking to your commercial ISP)
+* Combine with the [Hotspot app](https://github.com/YunoHost-Apps/hotspot_ynh) to broadcast VPN-protected WiFi to other laptops without any further technical configuration needed.
+
+
+
+**Versión actual:** 2.2~ynh3
+
+## Capturas
+
+![Captura de VPN Client](./doc/screenshots/vpnclient.png)
+
+## Documentaciones y recursos
+
+- Sitio web oficial: <https://labriqueinter.net>
+- Catálogo YunoHost: <https://apps.yunohost.org/app/vpnclient>
+- Reportar un error: <https://github.com/YunoHost-Apps/vpnclient_ynh/issues>
+
+## Información para desarrolladores
+
+Por favor enviar sus correcciones a la [`branch testing`](https://github.com/YunoHost-Apps/vpnclient_ynh/tree/testing
+
+Para probar la rama `testing`, sigue asÍ:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/vpnclient_ynh/tree/testing --debug
+o
+sudo yunohost app upgrade vpnclient -u https://github.com/YunoHost-Apps/vpnclient_ynh/tree/testing --debug
+```
+
+**Mas informaciones sobre el empaquetado de aplicaciones:** <https://yunohost.org/packaging_apps>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -3,7 +3,7 @@
 请勿手动编辑。
 -->
 
-# YunoHost 的 VPN Client
+# YunoHost 上的 VPN Client
 
 [![集成程度](https://dash.yunohost.org/integration/vpnclient.svg)](https://dash.yunohost.org/appci/app/vpnclient) ![工作状态](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
 

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -103,9 +103,20 @@ check_config() {
     critical "You need a CA server (you can add it through the web admin)"
   fi
 
-  if ! openssl x509 -in /etc/openvpn/keys/ca-server.crt -noout -checkend 0 >/dev/null; then
-    ca_server_cert_expired_date=$(openssl x509 -in /etc/openvpn/keys/ca-server.crt -noout -enddate | cut -d '=' -f 2)
-    critical "The CA server expired on $ca_server_cert_expired_date"
+  latest_ca_server_cert_expiry_timestamp=0
+  while ca_server_cert_expiry_date=$(openssl x509 -noout -enddate 2>/dev/null); do
+    ca_server_cert_expiry_date=$(cut -f 2 -d '=' <<< "$ca_server_cert_expiry_date")
+    ca_server_cert_expiry_timestamp=$(date +'%s' -d "$ca_server_cert_expiry_date")
+
+    if [[ "$ca_server_cert_expiry_timestamp" -ge "$latest_ca_server_cert_expiry_timestamp" ]]; then
+      latest_ca_server_cert_expiry_timestamp="$ca_server_cert_expiry_timestamp"
+      latest_ca_server_cert_expiry_date="$ca_server_cert_expiry_date"
+    fi
+  done < /etc/openvpn/keys/ca-server.crt
+
+  today_timestamp=$(date +'%s')
+  if [[ "$latest_ca_server_cert_expiry_timestamp" -ge "$today_timestamp" ]]; then
+    critical "The CA server expired on $latest_ca_server_cert_expiry_date"
   fi
 
   if [[ ! -e /etc/openvpn/keys/user.crt || ! -e /etc/openvpn/keys/user.key ]]; then

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -103,22 +103,6 @@ check_config() {
     critical "You need a CA server (you can add it through the web admin)"
   fi
 
-  latest_ca_server_cert_expiry_timestamp=0
-  while ca_server_cert_expiry_date=$(openssl x509 -noout -enddate 2>/dev/null); do
-    ca_server_cert_expiry_date=$(cut -f 2 -d '=' <<< "$ca_server_cert_expiry_date")
-    ca_server_cert_expiry_timestamp=$(date +'%s' -d "$ca_server_cert_expiry_date")
-
-    if [[ "$ca_server_cert_expiry_timestamp" -ge "$latest_ca_server_cert_expiry_timestamp" ]]; then
-      latest_ca_server_cert_expiry_timestamp="$ca_server_cert_expiry_timestamp"
-      latest_ca_server_cert_expiry_date="$ca_server_cert_expiry_date"
-    fi
-  done < /etc/openvpn/keys/ca-server.crt
-
-  today_timestamp=$(date +'%s')
-  if [[ "$latest_ca_server_cert_expiry_timestamp" -ge "$today_timestamp" ]]; then
-    critical "The CA server expired on $latest_ca_server_cert_expiry_date"
-  fi
-
   if [[ ! -e /etc/openvpn/keys/user.crt || ! -e /etc/openvpn/keys/user.key ]]; then
     if [[ -s /etc/openvpn/keys/credentials ]]; then
       login_user=$(sed -n 1p /etc/openvpn/keys/credentials)


### PR DESCRIPTION
## Problem

When there are multiple files in the same ca-server.crt (for instance, when there is both the new server certificate and the old one at the same time), we only check the expiration date of the first certificate in the file. Thus, if this certificate is the previous one and is expired, the VPN client can't start.

This is happening with Neutrinet VPN for instance...

## Solution

Either we remove that check, because it's probably redundant with OpenVPN client, or we fix this behaviour to handle multiple certs. This is what I did in this PR:
- I scrape the expiration date of each certificate in the file
- I retain the latest expiration date
- Then, I check if the latest expiration date is still valid

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
