### PR TITLE
Fix resolv.dnsmasq.conf ending up empty somehow

### DIFF
--- a/conf/scripts/route-down.d/20-vpnclient-unset-dns
+++ b/conf/scripts/route-down.d/20-vpnclient-unset-dns
@@ -20,9 +20,9 @@ if is_dns_set; then
   fi
 
   # FIXME : this situation happened to a user ...
-  # We could try to force regen the dns conf 
-  # (though for now it's tightly coupled to dnsmasq)
   if ! grep -q "^nameserver\s" "${resolvconf}"; then
-    echo "${resolvconf} does not have any nameserver line !?" >&2
+    echo "${resolvconf} does not have any nameserver line !? Regenerating ..." >&2
+    # This is the main line from yunohost's dnsmasq hook generating the resolv.dnsmasq.conf
+    cat /usr/share/yunohost/conf/dnsmasq/plain/resolv.dnsmasq.conf | grep "^nameserver" | shuf >${resolvconf}
   fi
 fi


### PR DESCRIPTION
## Problem

Saw an user with this issue where /etc/resolv.dnsmasq.conf ended up being empty for some reason ... I think because of some old ".ynh" file while in fact never gets deleted nor recreated ...

## Solution

We already detect if /etc/resolv.dnsmasq.conf is suspiciously empty, which breaks dnsmasq, so let's regenerate it with what the script from yunohost does (basically `cat /list/of/resolvers | shuf > $conf`)

## PR Status

Yolo
