### PR TITLE
Remove client.conf.tpl from /etc/openvpn

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -31,13 +31,6 @@ name = "Auto-configuration"
         bind = "/etc/openvpn/client.conf"
         redact = true
 
-        [main.vpn.config_template]
-        type = "file"
-        bind = "/etc/openvpn/client.conf.tpl"
-        redact = true
-        optional = true
-        visible = false
-
         [main.vpn.cube_file]
         type = "file"
         bind = "/etc/openvpn/client.cube"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -17,7 +17,6 @@ function vpnclient_deploy_files_and_services()
   mkdir -pm 0755 /etc/yunohost/hooks.d/post_iptable_rules/
   mkdir -pm 0755 /etc/systemd/system/openvpn@.service.d/
 
-  install -b -o root -g ${app} -m 0644 ../conf/openvpn_client.conf.tpl /etc/openvpn/client.conf.tpl
   install -b -o root -g root -m 0755 ../conf/hook_post-iptable-rules /etc/yunohost/hooks.d/90-vpnclient.tpl
   install -b -o root -g root -m 0644 ../conf/openvpn@.service /etc/systemd/system/openvpn@.service.d/override.conf
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -12,7 +12,6 @@ ynh_backup --src_path="/usr/local/bin/$service_name-loadcubefile.sh"
 
 ynh_backup --src_path="/etc/yunohost/hooks.d/90-vpnclient.tpl"
 
-ynh_backup --src_path="/etc/openvpn/client.conf.tpl"
 ynh_backup --src_path="/etc/openvpn/client.conf" --not_mandatory
 ynh_backup --src_path="/etc/openvpn/client.cube" --not_mandatory
 ynh_backup --src_path="/etc/openvpn/client.ovpn" --not_mandatory

--- a/scripts/remove
+++ b/scripts/remove
@@ -30,7 +30,6 @@ ynh_print_info "Removing openvpn configuration"
 
 # Remove openvpn configurations
 ynh_secure_remove /etc/openvpn/client.conf
-ynh_secure_remove /etc/openvpn/client.conf.tpl
 ynh_secure_remove /etc/openvpn/client.cube
 ynh_secure_remove /etc/openvpn/client.ovpn
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,7 +74,11 @@ yunohost service stop $service_name
 
 # Keep a copy of existing config files before overwriting them
 tmp_dir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
-cp -r /etc/openvpn/client* ${tmp_dir}
+for config_file in /etc/openvpn/client.{conf,cube,ovpn}; do
+  if [[ -f "${config_file}" ]]; then
+    cp "${config_file}" "${tmp_dir}"
+  fi
+done
 
 # Deploy files from package
 vpnclient_deploy_files_and_services

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -36,6 +36,10 @@ if [ -e "/etc/sudoers.d/${app}_ynh" ]; then
   ynh_secure_remove "/etc/sudoers.d/${app}_ynh"
 fi
 
+if [ -e "/etc/openvpn/client.conf.tpl" ]; then
+  ynh_secure_remove "/etc/openvpn/client.conf.tpl"
+fi
+
 # New stuff
 
 if [ -z "${dns_method:-}" ]; then
@@ -74,11 +78,7 @@ yunohost service stop $service_name
 
 # Keep a copy of existing config files before overwriting them
 tmp_dir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
-for config_file in /etc/openvpn/client.{conf,cube,ovpn}; do
-  if [[ -f "${config_file}" ]]; then
-    cp "${config_file}" "${tmp_dir}"
-  fi
-done
+cp /etc/openvpn/client.* "${tmp_dir}"
 
 # Deploy files from package
 vpnclient_deploy_files_and_services
@@ -100,7 +100,7 @@ then
 fi
 
 # Restore previously existing config files
-cp -r ${tmp_dir}/client* /etc/openvpn/
+cp ${tmp_dir}/client.* /etc/openvpn/
 ynh_secure_remove ${tmp_dir}
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -104,7 +104,11 @@ then
 fi
 
 # Restore previously existing config files
-cp -r "${tmp_dir}/" -T /etc/openvpn/
+for config_file in ${tmp_dir}/client.{conf,cube,ovpn}; do
+  if [[ -f "${config_file}" ]]; then
+    cp "${config_file}" /etc/openvpn/
+  fi
+done
 ynh_secure_remove ${tmp_dir}
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -78,7 +78,11 @@ yunohost service stop $service_name
 
 # Keep a copy of existing config files before overwriting them
 tmp_dir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
-cp /etc/openvpn/client.* "${tmp_dir}"
+for config_file in /etc/openvpn/client.{conf,cube,ovpn}; do
+  if [[ -f "${config_file}" ]]; then
+    cp "${config_file}" "${tmp_dir}/"
+  fi
+done
 
 # Deploy files from package
 vpnclient_deploy_files_and_services
@@ -100,7 +104,11 @@ then
 fi
 
 # Restore previously existing config files
-cp ${tmp_dir}/client.* /etc/openvpn/
+for config_file in ${tmp_dir}/client.{conf,cube,ovpn}; do
+  if [[ -f "${config_file}" ]]; then
+    cp "${config_file}" /etc/openvpn/
+  fi
+done
 ynh_secure_remove ${tmp_dir}
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -104,11 +104,7 @@ then
 fi
 
 # Restore previously existing config files
-for config_file in ${tmp_dir}/client.{conf,cube,ovpn}; do
-  if [[ -f "${config_file}" ]]; then
-    cp "${config_file}" /etc/openvpn/
-  fi
-done
+cp -r "${tmp_dir}/" -T /etc/openvpn/
 ynh_secure_remove ${tmp_dir}
 
 #=================================================


### PR DESCRIPTION
## Problem

The way we upgrade the client config is confusing:
1. We backup both the config files (client.conf, client.ovpn, client.cube) and the template (client.conf.tpl) in /etc/openvpn
2. We upgrade the template at /etc/openvpn/client.conf.tpl
3. In case the client.cube file exists, we apply the template in ./conf/openvpn_client.conf.tpl (not the one from /etc/openvpn)
4. We restore the template /etc/openvpn as it was in step 1.
5. We replace the config file with the one we upgraded (= we applied the new template on it)

At first, I thought the template in /etc/openvpn was never upgraded (which is the case), but actually it's never used at all!

## Solution

My solution is to remove the template in /etc/openvpn.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
