### PR TITLE
add optional script to route local ipv6 over tun interface

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -7,5 +7,6 @@
 - [Le o README en galego](README_gl.md)
 - [Baca README dalam bahasa bahasa Indonesia](README_id.md)
 - [Lees de README in het Nederlands](README_nl.md)
+- [Przeczytaj README w języku polski](README_pl.md)
 - [Прочитать README на русский](README_ru.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ It shall NOT be edited by hand.
 
 # VPN Client for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![Working status](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![Integration level](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Working status](https://apps.yunohost.org/badge/state/vpnclient)
+![Maintenance status](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![Install VPN Client with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,9 @@ No se debe editar a mano.
 
 # VPN Client para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Estado funcional](https://apps.yunohost.org/badge/state/vpnclient)
+![Estado En Mantención](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![Instalar VPN Client con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,9 @@ EZ editatu eskuz.
 
 # VPN Client YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![Integrazio maila](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Funtzionamendu egoera](https://apps.yunohost.org/badge/state/vpnclient)
+![Mantentze egoera](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![Instalatu VPN Client YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,9 @@ Il NE doit PAS être modifié à la main.
 
 # VPN Client pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![Niveau d’intégration](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Statut du fonctionnement](https://apps.yunohost.org/badge/state/vpnclient)
+![Statut de maintenance](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![Installer VPN Client avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,9 @@ NON debe editarse manualmente.
 
 # VPN Client para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Estado de funcionamento](https://apps.yunohost.org/badge/state/vpnclient)
+![Estado de mantemento](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![Instalar VPN Client con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/README_id.md
+++ b/README_id.md
@@ -5,7 +5,9 @@ Ini TIDAK boleh diedit dengan tangan.
 
 # VPN Client untuk YunoHost
 
-[![Tingkat integrasi](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![Status kerja](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Status pemeliharaan](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![Tingkat integrasi](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Status kerja](https://apps.yunohost.org/badge/state/vpnclient)
+![Status pemeliharaan](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![Pasang VPN Client dengan YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -5,7 +5,9 @@ Hij mag NIET handmatig aangepast worden.
 
 # VPN Client voor Yunohost
 
-[![Integratieniveau](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![Mate van functioneren](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Onderhoudsstatus](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![Integratieniveau](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Mate van functioneren](https://apps.yunohost.org/badge/state/vpnclient)
+![Onderhoudsstatus](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![VPN Client met Yunohost installeren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -1,0 +1,54 @@
+<!--
+To README zostało automatycznie wygenerowane przez <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Nie powinno być ono edytowane ręcznie.
+-->
+
+# VPN Client dla YunoHost
+
+[![Poziom integracji](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Status działania](https://apps.yunohost.org/badge/state/vpnclient)
+![Status utrzymania](https://apps.yunohost.org/badge/maintained/vpnclient)
+
+[![Zainstaluj VPN Client z YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
+
+*[Przeczytaj plik README w innym języku.](./ALL_README.md)*
+
+> *Ta aplikacja pozwala na szybką i prostą instalację VPN Client na serwerze YunoHost.*  
+> *Jeżeli nie masz YunoHost zapoznaj się z [poradnikiem](https://yunohost.org/install) instalacji.*
+
+## Przegląd
+
+Install a VPN connection on your self-hosted server.
+* Useful for hosting your server behind a filtered (and/or non-neutral) internet access.
+* Useful to have static IP addresses (IPv6 and IPv4).
+* Useful to easily move your server anywhere.
+* Strong firewalling (internet access and self-hosted services only available through the VPN, not leaking to your commercial ISP)
+* Combine with the [Hotspot app](https://github.com/YunoHost-Apps/hotspot_ynh) to broadcast VPN-protected WiFi to other laptops without any further technical configuration needed.
+
+
+
+**Dostarczona wersja:** 2.2~ynh6
+
+## Zrzuty ekranu
+
+![Zrzut ekranu z VPN Client](./doc/screenshots/vpnclient.png)
+
+## Dokumentacja i zasoby
+
+- Oficjalna strona aplikacji: <https://labriqueinter.net>
+- Sklep YunoHost: <https://apps.yunohost.org/app/vpnclient>
+- Zgłaszanie błędów: <https://github.com/YunoHost-Apps/vpnclient_ynh/issues>
+
+## Informacje od twórców
+
+Wyślij swój pull request do [gałęzi `testing`](https://github.com/YunoHost-Apps/vpnclient_ynh/tree/testing).
+
+Aby wypróbować gałąź `testing` postępuj zgodnie z instrukcjami:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/vpnclient_ynh/tree/testing --debug
+lub
+sudo yunohost app upgrade vpnclient -u https://github.com/YunoHost-Apps/vpnclient_ynh/tree/testing --debug
+```
+
+**Więcej informacji o tworzeniu paczek aplikacji:** <https://yunohost.org/packaging_apps>

--- a/README_ru.md
+++ b/README_ru.md
@@ -5,7 +5,9 @@
 
 # VPN Client для YunoHost
 
-[![Уровень интеграции](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![Состояние работы](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![Состояние сопровождения](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![Уровень интеграции](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![Состояние работы](https://apps.yunohost.org/badge/state/vpnclient)
+![Состояние сопровождения](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![Установите VPN Client с YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,9 @@
 
 # YunoHost 上的 VPN Client
 
-[![集成程度](https://dash.yunohost.org/integration/vpnclient.svg)](https://ci-apps.yunohost.org/ci/apps/vpnclient/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/vpnclient.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/vpnclient.maintain.svg)
+[![集成程度](https://apps.yunohost.org/badge/integration/vpnclient)](https://ci-apps.yunohost.org/ci/apps/vpnclient/)
+![工作状态](https://apps.yunohost.org/badge/state/vpnclient)
+![维护状态](https://apps.yunohost.org/badge/maintained/vpnclient)
 
 [![使用 YunoHost 安装 VPN Client](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vpnclient)
 

--- a/conf/optional-scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun
+++ b/conf/optional-scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ip -6 route flush table send_over_tun
+rm -f /etc/iproute2/rt_tables.d/vpnclient_ynh.conf

--- a/conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
+++ b/conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# cf https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/#environmental-variables
+# to have a list of variables provided by OpenVPN, i.e:
+# - dev
+# - net_gateway_ipv6
+# - ifconfig_ipv6_local
+gateway_interface=${dev}
+ip6_gw=${net_gateway_ipv6}
+
+if [[ -n "${net_gateway_ipv6}" ]]; then
+  echo "[INFO] Native IPv6 detected"
+  echo "[INFO] Autodetected native IPv6 gateway: ${ip6_gw}"
+
+  ip6_addr=$(yunohost app setting "vpnclient" "ip6_addr")
+  if [[ -z "${ip6_addr}" ]] || [[ "${ip6_addr}" == none ]]; then
+    if [[ -z ${ifconfig_ipv6_local} ]]; then
+      echo "[FAIL] Cannot find IPv6 address"
+      exit 1
+    fi
+    ip6_addr="${ifconfig_ipv6_local}"
+  fi
+
+  echo "[INFO] Found IPv6 address: ${ip6_addr}"
+
+  echo "1 send_over_tun" > /etc/iproute2/rt_tables.d/vpnclient_ynh.conf
+  ip -6 route flush table send_over_tun || true
+  ip -6 route add default via "${ip6_gw}" dev "${gateway_interface}" table send_over_tun proto static
+  ip -6 rule flush lookup send_over_tun
+  ip -6 rule add from "${ip6_addr}/64" pref 1 table send_over_tun
+fi

--- a/conf/scripts/route-up.d/30-vpnclient-set-server-ipv6-route
+++ b/conf/scripts/route-up.d/30-vpnclient-set-server-ipv6-route
@@ -26,10 +26,12 @@ wired_device=$(ip route | awk '/default via/ { print $5; }')
 # to have a list of variables provided by OpenVPN, i.e:
 # - ifconfig_ipv6_remote
 # - net_gateway_ipv6
+server_ip6=${ifconfig_ipv6_remote}
+ip6_gw=${net_gateway_ipv6}
 
 echo "[INFO] Autodetected internet interface: ${wired_device}"
-if [[ -n "${ifconfig_ipv6_remote}" ]]; then
-  echo "[INFO] Autodetected IPv6 address for the VPN server: ${ifconfig_ipv6_remote}"
+if [[ -n "${server_ip6}" ]]; then
+  echo "[INFO] Autodetected IPv6 address for the VPN server: ${server_ip6}"
 else
   echo "[INFO] No IPv6 address for the VPN server detected"
   echo "[INFO] No IPv6 route set"
@@ -37,15 +39,15 @@ else
 fi
 
 # Set the new server ipv6 route
-if [[ -n "${net_gateway_ipv6}" ]]; then
-  if ! is_serverip6route_set "${ifconfig_ipv6_remote}"; then
-    set_serverip6route "${ifconfig_ipv6_remote}" "${net_gateway_ipv6}" "${wired_device}"
+if [[ -n "${ip6_gw}" ]]; then
+  if ! is_serverip6route_set "${server_ip6}"; then
+    set_serverip6route "${server_ip6}" "${ip6_gw}" "${wired_device}"
   fi
 
   echo "[INFO] Native IPv6 detected"
-  echo "[INFO] Autodetected native IPv6 gateway: ${net_gateway_ipv6}"
+  echo "[INFO] Autodetected native IPv6 gateway: ${ip6_gw}"
 
-  if is_serverip6route_set "${ifconfig_ipv6_remote}"; then
+  if is_serverip6route_set "${server_ip6}"; then
     echo "[ OK ] IPv6 server route correctly set"
   else
     echo "[FAIL] No IPv6 server route set" >&2

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -130,3 +130,9 @@ name = "DNS & IPv6"
         help = "If no IPv6 address is pushed directly by your VPN provider, you can indicate a specific IP to use here."
         pattern.regexp = "^[0-9a-fA-F:]+$"
         pattern.error = "Please provide a valid IPv6"
+
+        [advanced.ipv6.ip6_send_over_tun_enabled]
+        ask = "IPv6 local routing over tun"
+        type = "boolean"
+        help = "If enabled, local IPv6 traffic will be routed through internet. You should enable this if you can't reach your server in IPv6 from your local network."
+

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -56,16 +56,18 @@ function read_cube() {
   local config_file="$1"
   local key="$2"
   local tmp_dir=$(dirname "$config_file")
+  local default_value="$3"
 
   setting_value="$(jq --raw-output ".$key" "$config_file")"
-  if [[ "$setting_value" == "null" ]]
-  then
-    setting_value=''
+  if [[ "$setting_value" == "null" ]]; then
+    setting_value="$default_value"
+  elif [[ "$setting_value" == "true" ]]; then
+    setting_value=1
+  elif [[ "$setting_value" == "false" ]]; then
+    setting_value=0
   # Save file in tmp dir
-  elif [[ "$key" == "crt_"* ]]
-  then
-    if [ -n "${setting_value}" ]
-    then
+  elif [[ "$key" == "crt_"* ]]; then
+    if [ -n "${setting_value}" ]; then
       echo "${setting_value}" | sed 's/|/\n/g' > "$tmp_dir/$key"
       setting_value="$tmp_dir/$key"
     fi
@@ -84,6 +86,7 @@ function convert_cube_file()
   server_proto="$(read_cube $config_file server_proto)"
   ip6_net="$(read_cube $config_file ip6_net)"
   ip6_addr="$(read_cube $config_file ip6_addr)"
+  ip6_send_over_tun_enabled="$(read_cube $config_file ip6_send_over_tun 0)"
   login_user="$(read_cube $config_file login_user)"
   login_passphrase="$(read_cube $config_file login_passphrase)"
   dns0="$(read_cube $config_file dns0)"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -56,7 +56,7 @@ function read_cube() {
   local config_file="$1"
   local key="$2"
   local tmp_dir=$(dirname "$config_file")
-  local default_value="$3"
+  local default_value="${3:-}"
 
   setting_value="$(jq --raw-output ".$key" "$config_file")"
   if [[ "$setting_value" == "null" ]]; then

--- a/scripts/config
+++ b/scripts/config
@@ -103,7 +103,6 @@ get__login_passphrase() {
     fi
 }
 
-
 #=================================================
 # SPECIFIC VALIDATORS FOR TOML SHORT KEYS
 #=================================================
@@ -190,6 +189,16 @@ set__login_user() {
 
 set__login_passphrase() {
     :
+}
+
+set__ip6_send_over_tun() {
+  if [[ ${ip6_send_over_tun_enabled} -eq 1 ]]; then
+    install -b -o root -g root -m 0755 ../conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun /etc/openvpn/scripts/route-up.d/
+    install -b -o root -g root -m 0755 ../conf/optional-scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun /etc/openvpn/scripts/route-down.d/
+  else
+    ynh_secure_remove /etc/openvpn/scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
+    ynh_secure_remove /etc/openvpn/scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun
+  fi
 }
 
 #=================================================

--- a/scripts/config
+++ b/scripts/config
@@ -191,15 +191,6 @@ set__login_passphrase() {
     :
 }
 
-set__ip6_send_over_tun_enabled() {
-  if [[ ${ip6_send_over_tun_enabled} -eq 1 ]]; then
-    install -b -o root -g root -m 0755 ../conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun /etc/openvpn/scripts/route-up.d/
-    install -b -o root -g root -m 0755 ../conf/optional-scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun /etc/openvpn/scripts/route-down.d/
-  else
-    ynh_secure_remove /etc/openvpn/scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
-    ynh_secure_remove /etc/openvpn/scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun
-  fi
-}
 
 #=================================================
 # OVERWRITING VALIDATE STEP
@@ -250,6 +241,14 @@ ynh_app_config_apply() {
     chmod go=--- /etc/openvpn/keys
 
     _ynh_app_config_apply
+
+    if [[ ${ip6_send_over_tun_enabled} -eq 1 ]]; then
+        install -b -o root -g root -m 0755 ../conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun /etc/openvpn/scripts/route-up.d/
+        install -b -o root -g root -m 0755 ../conf/optional-scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun /etc/openvpn/scripts/route-down.d/
+    else
+        ynh_secure_remove /etc/openvpn/scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun
+        ynh_secure_remove /etc/openvpn/scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun
+    fi
 
     set_permissions /etc/openvpn/client.conf
     set_permissions /etc/openvpn/keys/ca-server.crt

--- a/scripts/config
+++ b/scripts/config
@@ -191,7 +191,7 @@ set__login_passphrase() {
     :
 }
 
-set__ip6_send_over_tun() {
+set__ip6_send_over_tun_enabled() {
   if [[ ${ip6_send_over_tun_enabled} -eq 1 ]]; then
     install -b -o root -g root -m 0755 ../conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun /etc/openvpn/scripts/route-up.d/
     install -b -o root -g root -m 0755 ../conf/optional-scripts/route-down.d/50-vpnclient-unset-ipv6-send-over-tun /etc/openvpn/scripts/route-down.d/

--- a/scripts/config
+++ b/scripts/config
@@ -106,6 +106,7 @@ get__login_passphrase() {
 #=================================================
 # SPECIFIC VALIDATORS FOR TOML SHORT KEYS
 #=================================================
+
 validate__login_user() {
 
     if grep -q '^\s*auth-user-pass' ${config_file}
@@ -173,9 +174,11 @@ validate__nameservers() {
         echo "You need to choose DNS resolvers or select an other method to provide DNS resolvers"
     fi
 }
+
 #=================================================
 # SPECIFIC SETTERS FOR TOML SHORT KEYS
 #=================================================
+
 set__login_user() {
     if [ -n "${login_user}" ]
     then
@@ -191,37 +194,35 @@ set__login_passphrase() {
     :
 }
 
-
 #=================================================
 # OVERWRITING VALIDATE STEP
 #=================================================
+
 ynh_app_config_validate() {
     # At this moment this var is not already set with the old value
-    if [ -z ${config_file+x} ]
-    then
-        config_file="${old[config_file]}"
+    if [[ -n "${config_file:-}" ]]; then
+        # Overwrite form response with cube files data before validation process
 
-    # Overwrite form response with cube files data before validation process
+        # We don't have the extension, so we use this ugly hack to check that this is a json-like
+        # (i.e. it starts with { ..)
+        if [[ -f "${config_file}" ]]; then
+            if [[ "$(cat ${config_file} | tr -d ' ' | grep -v "^$" | head -c1)" == "{" ]]; then
+                local tmp_dir=$(dirname "$config_file")
 
-    # We don't have the extension, so we use this ugly hack to check that this is a json-like
-    # (i.e. it starts with { ..)
-    elif [ -f "${config_file}" ] && [[ "$(cat ${config_file} | tr -d ' ' | grep -v "^$" | head -c1)" == "{" ]]
-    then
-        local tmp_dir=$(dirname "$config_file")
+                cube_file="$tmp_dir/client.cube"
+                cp -f "$config_file" "$cube_file"
 
-        cube_file="$tmp_dir/client.cube"
-        cp -f "$config_file" "$cube_file"
+                convert_cube_file "$config_file"
+            # Othewise, assume that it's a .ovpn / .conf
+            else
+                local tmp_dir=$(dirname "$config_file")
 
-        convert_cube_file "$config_file"
-    # Othewise, assume that it's a .ovpn / .conf
-    elif [ -f "${config_file}" ]
-    then
-        local tmp_dir=$(dirname "$config_file")
+                ovpn_file="$tmp_dir/client.ovpn"
+                cp -f "$config_file" "$ovpn_file"
 
-        ovpn_file="$tmp_dir/client.ovpn"
-        cp -f "$config_file" "$ovpn_file"
-
-        convert_ovpn_file "$config_file"
+                convert_ovpn_file "$config_file"
+            fi
+        fi
     fi
 
     _ynh_app_config_validate
@@ -230,6 +231,7 @@ ynh_app_config_validate() {
 #=================================================
 # OVERWRITING APPLY STEP
 #=================================================
+
 ynh_app_config_apply() {
 
     # Stop vpn client
@@ -241,6 +243,15 @@ ynh_app_config_apply() {
     chmod go=--- /etc/openvpn/keys
 
     _ynh_app_config_apply
+
+    # If we are uploading a cube file, then the file would be in a temporary folder
+    # Otherwise, we aren't uploading a cube file, then the path is either empty 
+    # or takes the value of the previous upload, that is, the target path for the cube file.
+    if [[ -n "${cube_file:-}" && "$cube_file" != "/etc/openvpn/client.cube" ]]; then
+      ynh_app_setting_set $app ip6_addr "$ip6_addr"
+      ynh_app_setting_set $app ip6_net "$ip6_net"
+      ynh_app_setting_set $app ip6_send_over_tun_enabled "$ip6_send_over_tun_enabled"
+    fi
 
     if [[ ${ip6_send_over_tun_enabled} -eq 1 ]]; then
         install -b -o root -g root -m 0755 ../conf/optional-scripts/route-up.d/50-vpnclient-set-ipv6-send-over-tun /etc/openvpn/scripts/route-up.d/
@@ -257,8 +268,8 @@ ynh_app_config_apply() {
     set_permissions /etc/openvpn/keys/user_ta.key
 
     # Cleanup previously uploaded config file
-    [[ "$cube_file" == "/etc/openvpn/client.cube" ]] && rm -f "$cube_file"
-    [[ "$ovpn_file" == "/etc/openvpn/client.ovpn" ]] && rm -f "$ovpn_file"
+    [[ -n "${cube_file:-}" && "$cube_file" == "/etc/openvpn/client.cube" ]] && rm -f "$cube_file"
+    [[ -n "${ovpn_file:-}" && "$ovpn_file" == "/etc/openvpn/client.ovpn" ]] && rm -f "$ovpn_file"
 
     # Start vpn client
     ynh_print_info --message="Starting vpnclient service if needed"

--- a/scripts/install
+++ b/scripts/install
@@ -9,6 +9,7 @@ ynh_app_setting_set "$app" dns_method "yunohost"
 ynh_app_setting_set "$app" nameservers ""
 ynh_app_setting_set "$app" ip6_addr ""
 ynh_app_setting_set "$app" ip6_net ""
+ynh_app_setting_set "$app" ip6_send_over_tun_enabled 0
 
 #=================================================
 # DEPLOY FILES FROM PACKAGE

--- a/scripts/remove
+++ b/scripts/remove
@@ -14,8 +14,6 @@ systemctl stop $service_checker_name
 systemctl disable $service_checker_name --quiet
 
 if ynh_exec_warn_less yunohost service status $service_name >/dev/null; then
-    yunohost service stop $service_name
-    yunohost service disable $service_name --quiet
     yunohost service remove $service_name
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -62,6 +62,9 @@ fi
 if [ -z "${ip6_net:-}" ]; then
     ynh_app_setting_set --app=$app --key=ip6_net --value=""
 fi
+if [ -z "${ip6_send_over_tun_enabled:-}" ]; then
+    ynh_app_setting_set --app=$app --key=ip6_send_over_tun_enabled --value=0
+fi
 
 #=================================================
 # UPGRADE FROM BUSTER TO BULLSEYE


### PR DESCRIPTION
## Problem

Fix #59 

## Solution

I'm adding a option in the config panel to enable a script to route local IPv6 traffic over tun interface.

I'm not enabling this by default because I'm not sure it would work with all openvpn server...

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
