### PR TITLE
Add logrotate config

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -35,6 +35,7 @@ yunohost service add $service_name --description "Tunnels the internet traffic t
 yunohost service enable $service_name
 
 ynh_use_logrotate --logfile="/var/log/ynh-vpnclient.log"
+ynh_use_logrotate --logfile="/var/log/openvpn-client.log"
 
 # checker service
 

--- a/scripts/install
+++ b/scripts/install
@@ -34,6 +34,8 @@ systemctl stop openvpn
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/ynh-vpnclient.log"
 yunohost service enable $service_name
 
+ynh_use_logrotate --logfile="/var/log/ynh-vpnclient.log"
+
 # checker service
 
 systemctl start $service_checker_name

--- a/scripts/remove
+++ b/scripts/remove
@@ -16,6 +16,7 @@ systemctl disable $service_checker_name --quiet
 if ynh_exec_warn_less yunohost service status $service_name >/dev/null; then
     yunohost service remove $service_name
 fi
+ynh_remove_logrotate
 
 for FILE in $(ls /etc/systemd/system/$service_name* /usr/local/bin/ynh-vpnclient* /tmp/.ynh-vpnclient-*); do
     ynh_secure_remove "$FILE"

--- a/scripts/restore
+++ b/scripts/restore
@@ -29,6 +29,7 @@ yunohost service add $service_name --description "Tunnels the internet traffic t
 yunohost service enable "$service_name"
 
 ynh_use_logrotate --logfile="/var/log/ynh-vpnclient.log"
+ynh_use_logrotate --logfile="/var/log/openvpn-client.log"
 
 # checker service
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -28,6 +28,8 @@ systemctl stop openvpn
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/ynh-vpnclient.log"
 yunohost service enable "$service_name"
 
+ynh_use_logrotate --logfile="/var/log/ynh-vpnclient.log"
+
 # checker service
 
 systemctl start "$service_checker_name"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -128,6 +128,8 @@ ynh_print_info "Configuring VPN client services..."
 # main service
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/ynh-vpnclient.log"
 
+ynh_use_logrotate --logfile="/var/log/ynh-vpnclient.log"
+
 # checker service (this service was previously integrated in yunohost but we do not do this anymore)
 if ynh_exec_warn_less yunohost service status $service_checker_name >/dev/null
 then

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -129,6 +129,7 @@ ynh_print_info "Configuring VPN client services..."
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/ynh-vpnclient.log"
 
 ynh_use_logrotate --logfile="/var/log/ynh-vpnclient.log"
+ynh_use_logrotate --logfile="/var/log/openvpn-client.log"
 
 # checker service (this service was previously integrated in yunohost but we do not do this anymore)
 if ynh_exec_warn_less yunohost service status $service_checker_name >/dev/null


### PR DESCRIPTION
## Problem
I noticed there wasn't any logrotate config for the ynh-vpnclient 

## Solution

I'm just using the helper :p

Although, it would be good to have a logrotate config for `/var/log/openvpn-client.log`, but I'm not sure how to do it?

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
