### PR TITLE
Ensure OpenVPN log is written in file

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -189,6 +189,20 @@ function convert_ovpn_file()
   sed -i 's@^\s*key\s.*$@key /etc/openvpn/keys/user.key@g' ${config_file}
   sed -i 's@^\s*tls-auth\s.*$@tls-auth /etc/openvpn/keys/user_ta.key 1@g' ${config_file}
 
+  status="status /var/log/openvpn-client.status"
+  if grep -q '^\s*status\s.*$' ${config_file}; then
+    sed -i "s@^\s*status\s.*\$@$status@g" ${config_file}
+  else
+    echo "$status" >> ${config_file}
+  fi
+
+  log_append="log-append /var/log/openvpn-client.log"
+  if grep -q '^\s*log-append\s.*$' ${config_file}; then
+    sed -i "s@^\s*log-append\s.*\$@$log_append@g" ${config_file}
+  else
+    echo "$log_append" >> ${config_file}
+  fi
+
   script_security="script-security 2"
   if grep -q '^\s*script-security\s.*$' ${config_file}; then
     sed -i "s@^\s*script-security\s.*\$@$script_security@g" ${config_file}

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -197,8 +197,8 @@ function convert_ovpn_file()
   fi
 
   log_append="log-append /var/log/openvpn-client.log"
-  if grep -q '^\s*log-append\s.*$' ${config_file}; then
-    sed -i "s@^\s*log-append\s.*\$@$log_append@g" ${config_file}
+  if grep -E -q '^\s*log(-append)?\s.*$' ${config_file}; then
+    sed -E -i "s@^\s*log(-append)?\s.*\$@$log_append@g" ${config_file}
   else
     echo "$log_append" >> ${config_file}
   fi


### PR DESCRIPTION
## Problem

I noticed that in some case, OpenVPN logs aren't written in /var/log/openvpn-client.log

For instance, when the user import a custom .ovpn file, see this thread in the forum: https://forum.yunohost.org/t/solution-to-openvpn-only-working-in-command-line-not-vpnclient/35332

## Solution

When importing a .ovpn file, I'm checking if the directives `status` and `log-append` exists. If that's the case, I rewrite them to be sure it is writing to the correct log file (`/var/log/openvpn-client.log`), otherwise I add the directives in the config file.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
