### PR TITLE
Fix logrotate side effects

### DIFF
--- a/conf/openvpn_client.conf.tpl
+++ b/conf/openvpn_client.conf.tpl
@@ -34,8 +34,8 @@ __CERT_COMMENT__key /etc/openvpn/keys/user.key
 # Logs
 verb 3
 mute 5
-status /var/log/openvpn-client.status
-log-append /var/log/openvpn-client.log
+status /var/log/vpnclient/openvpn-client.status
+log-append /var/log/vpnclient/openvpn-client.log
 
 # Routing
 route-ipv6 2000::/3

--- a/conf/ynh-vpnclient
+++ b/conf/ynh-vpnclient
@@ -21,7 +21,7 @@
 # Logging helpers                                                                 #
 ###################################################################################
 
-LOGFILE="/var/log/ynh-vpnclient.log"
+LOGFILE="/var/log/vpnclient/ynh-vpnclient.log"
 touch $LOGFILE
 chown root:root $LOGFILE
 chmod 600 $LOGFILE
@@ -187,15 +187,15 @@ case "$action" in
     if systemctl start openvpn@client.service; then
       success "OpenVPN client started!"
     else
-      tail -n 20 /var/log/openvpn-client.log | tee -a $LOGFILE
+      tail -n 20 /var/log/vpnclient/openvpn-client.log | tee -a $LOGFILE
 	    critical "Failed to start OpenVPN client"
     fi
 
     info "Waiting for tun0 interface to show up"
-    openvpn_log_start=$(find_last_line_number "process exiting" /var/log/openvpn-client.log)
-    if ! timeout 180 tail -n-${openvpn_log_start} -f /var/log/openvpn-client.log 2>/dev/null | grep -q "TUN/TAP device tun0 opened"; then
+    openvpn_log_start=$(find_last_line_number "process exiting" /var/log/vpnclient/openvpn-client.log)
+    if ! timeout 180 tail -n-${openvpn_log_start} -f /var/log/vpnclient/openvpn-client.log 2>/dev/null | grep -q "TUN/TAP device tun0 opened"; then
       error "The VPN client didn't open tun0 interface"
-      tail -n 20 /var/log/openvpn-client.log | tee -a $LOGFILE
+      tail -n 20 /var/log/vpnclient/openvpn-client.log | tee -a $LOGFILE
       critical "Failed to start OpenVPN client"
     fi
 
@@ -203,14 +203,14 @@ case "$action" in
       success "tun0 interface is up!"
     else
       error "tun0 interface did not show up, most likely an issue happening in OpenVPN client"
-      tail -n 20 /var/log/openvpn-client.log | tee -a $LOGFILE
+      tail -n 20 /var/log/vpnclient/openvpn-client.log | tee -a $LOGFILE
       critical "Failed to start OpenVPN client"
     fi
 
     info "Waiting for VPN client to be ready..."
-    if ! timeout 180 tail -n-${openvpn_log_start} -f /var/log/openvpn-client.log 2>/dev/null | grep -q "Initialization Sequence Completed"; then
+    if ! timeout 180 tail -n-${openvpn_log_start} -f /var/log/vpnclient/openvpn-client.log 2>/dev/null | grep -q "Initialization Sequence Completed"; then
       error "The VPN client didn't complete initiliasation"
-      tail -n 20 /var/log/openvpn-client.log | tee -a $LOGFILE
+      tail -n 20 /var/log/vpnclient/openvpn-client.log | tee -a $LOGFILE
       critical "Failed to start OpenVPN client"
     fi
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -188,14 +188,14 @@ function convert_ovpn_file()
   sed -i 's@^\s*key\s.*$@key /etc/openvpn/keys/user.key@g' ${config_file}
   sed -i 's@^\s*tls-auth\s.*$@tls-auth /etc/openvpn/keys/user_ta.key 1@g' ${config_file}
 
-  status="status /var/log/openvpn-client.status"
+  status="status /var/log/vpnclient/openvpn-client.status"
   if grep -q '^\s*status\s.*$' ${config_file}; then
     sed -i "s@^\s*status\s.*\$@$status@g" ${config_file}
   else
     echo "$status" >> ${config_file}
   fi
 
-  log_append="log-append /var/log/openvpn-client.log"
+  log_append="log-append /var/log/vpnclient/openvpn-client.log"
   if grep -E -q '^\s*log(-append)?\s.*$' ${config_file}; then
     sed -E -i "s@^\s*log(-append)?\s.*\$@$log_append@g" ${config_file}
   else

--- a/scripts/install
+++ b/scripts/install
@@ -31,11 +31,10 @@ systemctl stop openvpn
 
 # main service
 
-yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/ynh-vpnclient.log"
+yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/vpnclient/ynh-vpnclient.log"
 yunohost service enable $service_name
 
-ynh_config_add_logrotate "/var/log/ynh-vpnclient.log"
-ynh_config_add_logrotate "/var/log/openvpn-client.log"
+ynh_config_add_logrotate
 
 # checker service
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -27,8 +27,7 @@ systemctl stop openvpn
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/ynh-vpnclient.log"
 yunohost service enable "$service_name"
 
-ynh_config_add_logrotate "/var/log/ynh-vpnclient.log"
-ynh_config_add_logrotate "/var/log/openvpn-client.log"
+ynh_config_add_logrotate
 
 # checker service
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -82,7 +82,7 @@ if [[ -e "/var/log/ynh-vpnclient.log" ]]; then
 fi
 # Fixing incorrect logrotate config
 if grep -q -e "/var/log/ynh-vpnclient.log" -e "/var/log/openvpn-client.log" "/etc/logrotate.d/$app"; then
-  ynh_config_rm_logrotate
+  ynh_config_remove_logrotate
   chmod 0755 /var/log
   chown root:root /var/log
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -76,6 +76,10 @@ if [[ -e "/var/log/openvpn-client.log" ]]; then
   mkdir -p "/var/log/$app"
   mv "/var/log/openvpn-client.log" "/var/log/$app/"
 fi
+if [[ -e "/var/log/openvpn-client.status" ]]; then
+  mkdir -p "/var/log/$app"
+  mv "/var/log/openvpn-client.status" "/var/log/$app/"
+fi
 if [[ -e "/var/log/ynh-vpnclient.log" ]]; then
   mkdir -p "/var/log/$app"
   mv "/var/log/ynh-vpnclient.log" "/var/log/$app/"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -71,6 +71,22 @@ ynh_print_info "Stopping VPN client to apply config changes..."
 ynh_systemctl --action="stop" --service="$service_checker_name.timer"
 yunohost service stop $service_name
 
+# Moving log files from legacy location
+if [[ -e "/var/log/openvpn-client.log" ]]; then
+  mkdir -p "/var/log/$app"
+  mv "/var/log/openvpn-client.log" "/var/log/$app/"
+fi
+if [[ -e "/var/log/ynh-vpnclient.log" ]]; then
+  mkdir -p "/var/log/$app"
+  mv "/var/log/ynh-vpnclient.log" "/var/log/$app/"
+fi
+# Fixing incorrect logrotate config
+if grep -q -e "/var/log/ynh-vpnclient.log" -e "/var/log/openvpn-client.log" "/etc/logrotate.d/$app"; then
+  ynh_config_rm_logrotate
+  chmod 0755 /var/log
+  chown root:root /var/log
+fi
+
 # Keep a copy of existing config files before overwriting them
 tmp_dir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
 for config_file in /etc/openvpn/client.{conf,cube,ovpn}; do
@@ -114,10 +130,9 @@ ynh_safe_rm "${tmp_dir}"
 ynh_print_info "Configuring VPN client services..."
 
 # main service
-yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/ynh-vpnclient.log"
+yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/$app/ynh-vpnclient.log"
 
-ynh_config_add_logrotate "/var/log/ynh-vpnclient.log"
-ynh_config_add_logrotate "/var/log/openvpn-client.log"
+ynh_config_add_logrotate
 
 # checker service (this service was previously integrated in yunohost but we do not do this anymore)
 if ynh_hide_warnings yunohost service status $service_checker_name >/dev/null

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -44,6 +44,13 @@ if [ -e "/etc/openvpn/client.conf.tpl" ]; then
   ynh_safe_rm "/etc/openvpn/client.conf.tpl"
 fi
 
+# Fixing incorrect logrotate config
+if grep -q -e "/var/log/ynh-vpnclient.log" -e "/var/log/openvpn-client.log" "/etc/logrotate.d/$app"; then
+  ynh_config_remove_logrotate
+  chmod 0755 /var/log
+  chown root:root /var/log
+fi
+
 # New stuff
 
 ynh_app_setting_set_default --key="dns_method" --value="custom"
@@ -70,26 +77,6 @@ ynh_print_info "Stopping VPN client to apply config changes..."
 
 ynh_systemctl --action="stop" --service="$service_checker_name.timer"
 yunohost service stop $service_name
-
-# Moving log files from legacy location
-if [[ -e "/var/log/openvpn-client.log" ]]; then
-  mkdir -p "/var/log/$app"
-  mv "/var/log/openvpn-client.log" "/var/log/$app/"
-fi
-if [[ -e "/var/log/openvpn-client.status" ]]; then
-  mkdir -p "/var/log/$app"
-  mv "/var/log/openvpn-client.status" "/var/log/$app/"
-fi
-if [[ -e "/var/log/ynh-vpnclient.log" ]]; then
-  mkdir -p "/var/log/$app"
-  mv "/var/log/ynh-vpnclient.log" "/var/log/$app/"
-fi
-# Fixing incorrect logrotate config
-if grep -q -e "/var/log/ynh-vpnclient.log" -e "/var/log/openvpn-client.log" "/etc/logrotate.d/$app"; then
-  ynh_config_remove_logrotate
-  chmod 0755 /var/log
-  chown root:root /var/log
-fi
 
 # Keep a copy of existing config files before overwriting them
 tmp_dir=$(mktemp -d /tmp/vpnclient-upgrade-XXX)
@@ -137,6 +124,17 @@ ynh_print_info "Configuring VPN client services..."
 yunohost service add $service_name --description "Tunnels the internet traffic through a VPN" --need_lock --test_status="systemctl is-active openvpn@client.service" --log "/var/log/$app/ynh-vpnclient.log"
 
 ynh_config_add_logrotate
+
+# Moving log files from legacy location
+if [[ -e "/var/log/openvpn-client.log" ]]; then
+  mv "/var/log/openvpn-client.log" "/var/log/$app/"
+fi
+if [[ -e "/var/log/openvpn-client.status" ]]; then
+  mv "/var/log/openvpn-client.status" "/var/log/$app/"
+fi
+if [[ -e "/var/log/ynh-vpnclient.log" ]]; then
+  mv "/var/log/ynh-vpnclient.log" "/var/log/$app/"
+fi
 
 # checker service (this service was previously integrated in yunohost but we do not do this anymore)
 if ynh_hide_warnings yunohost service status $service_checker_name >/dev/null


### PR DESCRIPTION
## Problem

I noticed that the helper function `ynh_config_add_logrotate` had side effects when we configure it with a file directly inside `/var/log`, for instance `/var/log/openvpn-client.log` and `/var/log/ynh-vpnclient.log`. The function changes ownership and permissions to the `/var/log` directory. As a consequence, I had a 502 error on the Yunohost portal, because it wasn't able to write logs anymore.

## Solution

Moving the VPN client logs to a dedicated directory (`/var/log/vpnclient`) and cleaning up the mess when we upgrade.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
