### PR TITLE
fix config template location when the app is upgraded

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -104,7 +104,6 @@ function convert_cube_file()
 
   # Build specific OVPN template
   config_template="$tmp_dir/client.conf.tpl"
-  cp -f /etc/yunohost/apps/vpnclient/conf/openvpn_client.conf.tpl "$config_template"
   # Remove some lines
   jq --raw-output '.openvpn_rm[]' "${config_file}" | while read -r rm_regex
   do

--- a/scripts/config
+++ b/scripts/config
@@ -198,6 +198,8 @@ ynh_app_config_validate() {
 
                 cube_file="$tmp_dir/client.cube"
                 cp -f "$config_file" "$cube_file"
+                # We copy the config template because it will be modified later
+                cp -f "/etc/yunohost/apps/vpnclient/conf/openvpn_client.conf.tpl" "$tmp_dir/client.conf.tpl"
 
                 convert_cube_file "$config_file"
             # Othewise, assume that it's a .ovpn / .conf

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -93,6 +93,8 @@ vpnclient_deploy_files_and_services
 if [[ -f "$tmp_dir/client.cube" ]]
 then
     cp -f "$tmp_dir/client.cube" "$tmp_dir/client.conf"
+    # We copy the config template because it will be modified later
+    cp -f "../conf/openvpn_client.conf.tpl" "$tmp_dir/client.conf.tpl"
     convert_cube_file "$tmp_dir/client.conf"
 elif [[ -f "$tmp_dir/client.ovpn" ]]
 then


### PR DESCRIPTION
## Problem

See https://forum.yunohost.org/t/erreur-mise-a-jour-vpnclient-de-2-3-ynh1-vers-2-3ynh3/36893/4

## Solution

I'm copying the config template in the temp directory before converting the cube file into a config file.
This way, we can define another path when we upgrade the app.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
